### PR TITLE
Travis: fix the git identity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,10 @@ matrix:
     - python: 2.6
     - python: 3.2
     - python: 3.3
+before_install:
+  - git config --global user.email "hashdist@h.com";
+    git config --global user.name "Hashdist"
 script:
-  - nosetests -v
+  - nosetests -v -s
 notifications:
   email: false


### PR DESCRIPTION
Git needs to setup the identity in order to be able to commit. So we fix this
for Travis.

Also we leave stdout in the output of tests to ease debugging.
