### PR TITLE
Catch exceptions in main.py

### DIFF
--- a/hashdist/cli/main.py
+++ b/hashdist/cli/main.py
@@ -126,8 +126,7 @@ def main(unparsed_argv, env, logger=None):
                 stack trace.
                 """
                 print(textwrap.fill(textwrap.dedent(text), width=78), file=sys.stderr)
-            sys.exit(127)
-
+            retcode = 127
 
     return retcode
 


### PR DESCRIPTION
Fixes #31. An example of new behavior:

```
ondrej@hawk:~/repos/hashdist(fix31v2)$ PYTHONPATH=. bin/hdist fetch https://github.com/hashdist/hashdist
Uncaught exception:
Traceback (most recent call last):
  File "/home/ondrej/repos/hashdist/hashdist/cli/main.py", line 114, in main
    retcode = args.subcommand_handler(ctx, args)
  File "/home/ondrej/repos/hashdist/hashdist/cli/source_cache_cli.py", line 74, in run
    key = store.fetch_archive(args.url, args.type)
  File "/home/ondrej/repos/hashdist/hashdist/core/source_cache.py", line 212, in fetch_archive
    return ArchiveSourceCache(self).fetch_archive(url, type, None)
  File "/home/ondrej/repos/hashdist/hashdist/core/source_cache.py", line 558, in fetch_archive
    type = self._ensure_type(url, type)
  File "/home/ondrej/repos/hashdist/hashdist/core/source_cache.py", line 539, in _ensure_type
    raise ValueError('Unable to guess archive type of "%s"' % url)
ValueError: Unable to guess archive type of "https://github.com/hashdist/hashdist"

This exception has not been translated to a human-friendly error message,
please file an issue at https://github.com/hashdist/hashdist/issues pasting
this stack trace.
```

v.s. old behavior:

```
ondrej@hawk:~/repos/hashdist((65df19f...))$ PYTHONPATH=. bin/hdist fetch https://github.com/hashdist/hashdist
Traceback (most recent call last):
  File "bin/hdist", line 6, in <module>
    sys.exit(main(sys.argv, os.environ))
  File "/home/ondrej/repos/hashdist/hashdist/cli/main.py", line 110, in main
    retcode = args.subcommand_handler(ctx, args)
  File "/home/ondrej/repos/hashdist/hashdist/cli/source_cache_cli.py", line 74, in run
    key = store.fetch_archive(args.url, args.type)
  File "/home/ondrej/repos/hashdist/hashdist/core/source_cache.py", line 212, in fetch_archive
    return ArchiveSourceCache(self).fetch_archive(url, type, None)
  File "/home/ondrej/repos/hashdist/hashdist/core/source_cache.py", line 558, in fetch_archive
    type = self._ensure_type(url, type)
  File "/home/ondrej/repos/hashdist/hashdist/core/source_cache.py", line 539, in _ensure_type
    raise ValueError('Unable to guess archive type of "%s"' % url)
ValueError: Unable to guess archive type of "https://github.com/hashdist/hashdist"
```
