### PR TITLE
use absolute paths for temporary directories

### DIFF
--- a/hashdist/core/test/utils.py
+++ b/hashdist/core/test/utils.py
@@ -15,6 +15,10 @@ from logging import getLevelName
 
 from os.path import join as pjoin
 
+
+def make_abs_temp_dir():
+    return os.path.realpath(tempfile.mkdtemp())
+
 # Make our own assert_raises, as nose.tools doesn't have it on Python 2.6
 # We always use the context manager form
 @contextlib.contextmanager
@@ -32,7 +36,7 @@ def assert_raises(wanted_exc_type):
 
 @contextlib.contextmanager
 def temp_dir():
-    tempdir = tempfile.mkdtemp()
+    tempdir = make_abs_temp_dir()
     try:
         yield tempdir
     finally:
@@ -40,7 +44,7 @@ def temp_dir():
 
 @contextlib.contextmanager
 def temp_working_dir():
-    tempdir = tempfile.mkdtemp()
+    tempdir = make_abs_temp_dir()
     try:
         with working_directory(tempdir):
             yield tempdir
@@ -112,10 +116,10 @@ def make_temporary_tarball(files):
     from ..source_cache import scatter_files
     from ..hasher import format_digest
     
-    container_dir = tempfile.mkdtemp()
+    container_dir = make_abs_temp_dir()
     archive_filename = pjoin(container_dir, 'archive.tar.gz')
 
-    tmp_d = tempfile.mkdtemp()
+    tmp_d = make_abs_temp_dir()
     try:
         scatter_files(files, tmp_d)
         with closing(tarfile.open(archive_filename, 'w:gz')) as archive:


### PR DESCRIPTION
This works around an OS X.8 issue where os.path.realpath(d) resolves to
a different dir than d when d = tempfile.mkdtemp()

This PR supersedes #105 and #108
