### PR TITLE
Refactor tests for better portability, other fixes

### DIFF
--- a/hashdist/cli/test/test_build_tools.py
+++ b/hashdist/cli/test/test_build_tools.py
@@ -7,7 +7,7 @@ from nose.tools import eq_, ok_
 
 
 from ...core.test import utils
-
+from ...core.test.utils import which
 from ...core.test.test_build_store import fixture
 
 
@@ -87,23 +87,16 @@ def test_build_profile(tempdir, sc, bldr, cfg):
     # 3) That "share" does not disappear (contains another file created in meantime),
     #    but "should-be-removed" does (empty after popping profile).
 
-    if os.path.exists('/usr/bin/readlink'):
-        readlink = '/usr/bin/readlink'
-    elif os.path.exists('/bin/readlink'):
-        readlink = '/bin/readlink'
-    else:
-        raise OSError('Unable to find system readlink')
-
     app_spec = {
         "name": "app",
         "version": "n",
         "build": {
             "import": [{"id": corelib_id}],
             "commands": [
-                {"cmd": ["/bin/echo", "hello world"], "append_to_file": "$ARTIFACT/hello"}, # must not be removed by pop
+                {"cmd": [which("echo"), "hello world"], "append_to_file": "$ARTIFACT/hello"}, # must not be removed by pop
                 {"hit": ["build-profile", "push"]},
-                {"cmd": ["/bin/echo", "hello world"], "append_to_file": "$ARTIFACT/share/foo"}, # preserve "share" dir
-                {"cmd": [readlink, "$ARTIFACT/should-be-removed/hello"], "append_to_file": "$ARTIFACT/result"},
+                {"cmd": [which("echo"), "hello world"], "append_to_file": "$ARTIFACT/share/foo"}, # preserve "share" dir
+                {"cmd": [which("readlink"), "$ARTIFACT/should-be-removed/hello"], "append_to_file": "$ARTIFACT/result"},
                 {"hit": ["build-profile", "pop"]},
                 ]
             }

--- a/hashdist/core/run_job.py
+++ b/hashdist/core/run_job.py
@@ -438,7 +438,7 @@ class CommandTreeExecution(object):
         self.log_fifo_filenames = {}
         if temp_dir is None:
             self.rm_temp_dir = True
-            temp_dir = tempfile.mkdtemp(prefix='hashdist-run-job-')
+            temp_dir = os.path.realpath(tempfile.mkdtemp(prefix='hashdist-run-job-'))
         else:
             if os.listdir(temp_dir) != []:
                 raise Exception('temp_dir must be an empty directory')

--- a/hashdist/core/test/test_build_store.py
+++ b/hashdist/core/test/test_build_store.py
@@ -14,7 +14,7 @@ from pprint import pprint
 from nose.tools import eq_
 from nose import SkipTest
 
-from .utils import logger, temp_dir, temp_working_dir, assert_raises
+from .utils import which, logger, temp_dir, temp_working_dir, assert_raises
 from . import utils
 
 from .. import source_cache, build_store, InvalidBuildSpecError, BuildFailedError, InvalidJobSpecError
@@ -101,7 +101,7 @@ def test_basic(tempdir, sc, bldr, config):
     script_key = sc.put({'build.sh': dedent("""\
     echo hi stdout path=[$PATH]
     echo hi stderr>&2
-    /usr/bin/find > ${ARTIFACT}/hello
+    /usr/bin/find . > ${ARTIFACT}/hello
     """)})
     spec = {
         "name": "foo",
@@ -166,9 +166,9 @@ def test_failing_build_and_multiple_commands(tempdir, sc, bldr, config):
     spec = {"name": "foo", "version": "na",
             "build": {
                 "commands": [
-                    {"cmd": ["/bin/echo", "test"], "append_to_file": "foo2"},
-                    {"cmd": ["/bin/true"]},
-                    {"cmd": ["/bin/false"]},
+                    {"cmd": [which("echo"), "test"], "append_to_file": "foo2"},
+                    {"cmd": [which("true")]},
+                    {"cmd": [which("false")]},
                 ]
            }}
     try:
@@ -211,7 +211,7 @@ def test_hash_prefix_collision(tempdir, sc, bldr, config):
         for k in range(15):
             spec = {"name": "foo", "version": "na",
                     "build": {
-                        "commands": [{"cmd": ["/bin/echo", "hello", str(k)]}]
+                        "commands": [{"cmd": [which("echo"), "hello", str(k)]}]
                         }
                     }
             artifact_id, path = bldr.ensure_present(spec, config)
@@ -272,7 +272,7 @@ def build_mock_packages(builder, config, packages, virtuals={}, name_to_artifact
     if name_to_artifact is None:
         name_to_artifact = {} # name -> (artifact_id, path)
     for pkg in packages:
-        script = ['/bin/touch ${ARTIFACT}/deps\n']
+        script = [which('touch') + ' ${ARTIFACT}/deps\n']
         script += ['echo %(x)s $%(x)s_ID $%(x)s >> ${ARTIFACT}/deps' % dict(x=dep.name)
                    for dep in pkg.deps]
         spec = {"name": pkg.name, "version": "na",

--- a/hashdist/core/test/test_run_job.py
+++ b/hashdist/core/test/test_run_job.py
@@ -10,7 +10,7 @@ from nose import SkipTest
 from .. import run_job
 from .test_build_store import fixture as build_store_fixture
 
-from .utils import MemoryLogger, logger as test_logger, assert_raises
+from .utils import which, MemoryLogger, logger as test_logger, assert_raises
 
 env_to_stderr = [sys.executable, '-c',
                  "import os, sys; sys.stderr.write("
@@ -220,7 +220,7 @@ def test_attach_log(tempdir, sc, build_store, cfg):
 def test_error_exit(tempdir, sc, build_store, cfg):
     job_spec = {
         "commands": [
-            {"cmd": ["/bin/false"]},
+            {"cmd": [which("false")]},
         ]}
     logger = MemoryLogger()
     with assert_raises(CalledProcessError):

--- a/hashdist/core/test/utils.py
+++ b/hashdist/core/test/utils.py
@@ -15,9 +15,21 @@ from logging import getLevelName
 
 from os.path import join as pjoin
 
+def which(filename):
+    """Checks PATH for the location of filename"""
+
+    locations = os.environ.get("PATH").split(os.pathsep)
+    for location in locations:
+        candidate = os.path.join(location, filename)
+        if os.path.isfile(candidate):
+            return candidate
+    raise OSError('Unable to find system %s' % filename,)
+
 
 def make_abs_temp_dir():
+    """Create a temporary directory and get its absolute path"""
     return os.path.realpath(tempfile.mkdtemp())
+
 
 # Make our own assert_raises, as nose.tools doesn't have it on Python 2.6
 # We always use the context manager form


### PR DESCRIPTION
- added test.utils.which to determine PATH of standard utilities
- added missing "." in test build script
- now using os.path.realpath on run_job tmp directory
