### PR TITLE
FTP protocol is supported, remove the check

### DIFF
--- a/hashdist/core/source_cache.py
+++ b/hashdist/core/source_cache.py
@@ -556,9 +556,6 @@ class ArchiveSourceCache(object):
                 stream = open(url[len('file:'):])
             except IOError as e:
                 raise SourceNotFoundError(str(e))
-        elif url.startswith('ftp://'):
-            self.logger.error('ftp protocol not supported: %s' % url)
-            raise NotImplementedError('ftp download has problems')
         else:
             # Make request.
             sys.stderr.write('Downloading %s...\n' % url)


### PR DESCRIPTION
The FTP protocol has always been working for me, and
some packages like GMP require it.

/cc @dagss, @ahmadia
