### PR TITLE
Global environment variables for builds

### DIFF
--- a/hashdist/spec/package.py
+++ b/hashdist/spec/package.py
@@ -366,6 +366,11 @@ def create_build_spec(pkg_name, pkg_doc, parameters, dependency_id_map,
     # build commands
     commands = list(dependency_commands)
     commands.append({"set": "BASH", "nohash_value": parameters['BASH']})
+
+    for par_name in parameters:
+        if par_name.startswith('HASHDIST_BUILDENV_'):
+            commands.insert(0, {"set": par_name[18:], "nohash_value": parameters[par_name]})
+
     if 'PATH' in parameters:
         commands.insert(0, {"set": "PATH", "nohash_value": parameters['PATH']})
     commands.append({"cmd": ["$BASH", "_hashdist/build.sh"]})


### PR DESCRIPTION
Add parameter support for global environment variables set for every
build.  This is useful for cross-compiling or multi-toolchain
environments such as OS X.  It is also likely to be very similar to the
approach we will take for loading in module files prior to builds on HPC
resources.
