### PR TITLE
Added "copy" as profile link option

### DIFF
--- a/hashdist/spec/package.py
+++ b/hashdist/spec/package.py
@@ -110,8 +110,16 @@ class PackageSpec(object):
                               "select": "${%s_DIR}/%s" % (ref, select),
                               "prefix": "${%s_DIR}" % ref,
                               "target": target})
+            elif 'copy' in in_stage:
+                select = substitute_profile_parameters(in_stage["copy"], parameters)
+                rules.append({"action": "copy",
+                    "select": "${%s_DIR}/%s" % (ref, select),
+                    "prefix": "${%s_DIR}" % ref,
+                    "target": target,
+                    "dirs": in_stage.get("dirs", False)})
+
             else:
-                raise ValueError('Need either "link", "launcher" or "exclude" key in profile_links entries')
+                raise ValueError('Need either "copy", "link", "launcher" or "exclude" key in profile_links entries')
         return rules
 
     def assemble_build_import_commands(self, parameters, ref):


### PR DESCRIPTION
This enables techniques such as copying executables instead of
using launcher scripts and copying DLLs and other artifacts that
need to be in a specific location.

See the parallel https://github.com/hashdist/hashstack2/pull/63 for 
an example of this for DLL creation in Cygwin packages.
