### PR TITLE
More graceful handling of remote errors

### DIFF
--- a/hashdist/cli/main.py
+++ b/hashdist/cli/main.py
@@ -17,6 +17,7 @@ import errno
 from ..formats.config import (load_config_file, DEFAULT_CONFIG_FILENAME_REPR, DEFAULT_CONFIG_FILENAME,
                               ValidationError)
 from ..formats.marked_yaml import ValidationError
+from ..core.source_cache import RemoteFetchError
 from ..hdist_logging import Logger, DEBUG, INFO
 
 try:
@@ -186,6 +187,12 @@ def help_on_exceptions(logger, func, *args, **kw):
             raise
         else:
             logger.error(str(e))
+            return 127
+    except RemoteFetchError as e:
+        if debug:
+            raise
+        else:
+            logger.error("You may wish to check your Internet connection or the remote server")
             return 127
     except:
         if debug:

--- a/hashdist/core/decorators.py
+++ b/hashdist/core/decorators.py
@@ -1,0 +1,86 @@
+from time import sleep
+from functools import wraps
+from hashdist.hdist_logging import Logger
+
+# The retry function derives from a version by Jeff Laughlin Consulting
+# LLC, which is available from https://gist.github.com/n1ywb/2570004
+# under the following license:
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+def _default_retry(tries_remaining, exception, delay):
+    msg = "Retrying in %s seconds, %d tries remaining" % \
+          (delay, tries_remaining)
+    logger = Logger()
+    logger.info(msg)
+    logger.info("Press Control-C to give up")
+
+def retry(max_tries=3, delay=1, backoff=2, exceptions=(Exception,),
+          hook_retry=_default_retry):
+    """Function decorator implementing retrying logic.
+
+    max_tries: Number of attempts to make before giving up
+    delay: Factor of seconds to sleep in sleep = (delay * backoff * try number)
+    backoff: Number to multiply delay after each failure
+    exceptions: Iterable of exception classes; default (Exception,)
+    hook_retry: Function with signature hook_retry(tries_remaining, exception);
+                If specified, this function is called prior to each retry
+
+    The decorated function will be retried up to max_tries times if it raises
+    an exception.
+
+    By default, catch instances of the Exception class and subclasses.
+    This will recover after all but the most fatal errors. You may specify a
+    custom tuple of exception classes with the 'exceptions' argument; the
+    function will only be retried if it raises one of the specified
+    exceptions.
+
+    Additionally you may specify hook functions which will be called prior
+    to retrying with the number of remaining tries and the exception instance;
+    This is primarily intended to give the opportunity to
+    log the failure. hook_retry is not called after failure if no
+    retries remain.
+    """
+
+    def deco_retry(f):
+
+        @wraps(f)
+        def f_retry(*args, **kwargs):
+            my_delay = delay
+            tries = range(max_tries)
+            tries.reverse()
+            for tries_remaining in tries:
+                try:
+                   return f(*args, **kwargs)
+                except exceptions as e:
+                    if tries_remaining > 0:
+                        if hook_retry is not None:
+                            hook_retry(tries_remaining, e, my_delay)
+                        sleep(my_delay)
+                        my_delay = my_delay * backoff
+                    else:
+                        raise
+                else:
+                    break
+            return f(*args, **kwargs)
+
+        return f_retry
+
+    return deco_retry

--- a/hashdist/core/source_cache.py
+++ b/hashdist/core/source_cache.py
@@ -101,6 +101,7 @@ from contextlib import closing
 
 from .hasher import hash_document, format_digest, HashingReadStream, HashingWriteStream
 from .fileutils import silent_makedirs
+from .decorators import retry
 
 pjoin = os.path.join
 
@@ -109,6 +110,9 @@ TAG_RE = re.compile(TAG_RE_S)
 
 PACKS_DIRNAME = 'packs'
 GIT_DIRNAME = 'git'
+
+class RemoteFetchError(Exception):
+    pass
 
 class SourceCacheError(Exception):
     pass
@@ -239,7 +243,7 @@ class SourceCache(object):
         key : str
             The globally unique key; this is the git commit SHA-1 hash
             prepended by ``git:``.
-        
+
         """
         return GitSourceCache(self).fetch_git(repository, rev, repo_name)
 
@@ -258,7 +262,7 @@ class SourceCache(object):
         type : str (optional)
             Type of archive, such as ``"tar.gz"``, ``"tar.gz2"``. For use
             when this cannot be determined from the suffix of the url.
-        
+
         """
         return ArchiveSourceCache(self).fetch_archive(url, type, None)
 
@@ -291,6 +295,7 @@ class SourceCache(object):
             raise ValueError('does not recognize key prefix: %s' % type)
         return handler
 
+    @retry(max_tries=3, exceptions=(RemoteFetchError))
     def fetch(self, url, key, repo_name=None):
         """Fetch sources whose key is known.
 
@@ -361,29 +366,30 @@ class GitSourceCache(object):
         self.repo_path = pjoin(source_cache.cache_path, GIT_DIRNAME)
         self.logger = source_cache.logger
 
-    def git_interactive(self, repo_name, *args):
+    def git(self, repo_name, *args):
         # Inherit stdin/stdout in order to interact with user about any passwords
         # required to connect to any servers and so on
         if args[0] == 'init':
             env = os.environ
         else:
             env = self.get_repo_env(repo_name)
-        subprocess.check_call(['git'] + list(args), env=env)
-
-    def git(self, repo_name, *args):
-        p = subprocess.Popen(['git'] + list(args), env=self.get_repo_env(repo_name),
+        p = subprocess.Popen(['git'] + list(args), env=env,
                              stdout=subprocess.PIPE, stdin=subprocess.PIPE,
                              stderr=subprocess.PIPE)
         out, err = p.communicate()
         return p.returncode, out, err
 
     def checked_git(self, repo_name, *args):
+        if args[0] in ['ls-remote', 'fetch']:
+            error_dispatch=RemoteFetchError
+        else:
+            error_dispatch=RuntimeError
         retcode, out, err = self.git(repo_name, *args)
         # Just fetch the output
         if retcode != 0:
             msg = 'git call %r failed with code %d' % (args, retcode)
-            self.logger.error("Problem when trying to download repo %s: %s" % (repo_name, msg))
-            raise RuntimeError(msg)
+            self.logger.error(msg)
+            raise error_dispatch(msg)
         return out
 
     def get_repo_env(self, repo_name):
@@ -419,7 +425,7 @@ class GitSourceCache(object):
     def _does_branch_exist(self, repo_name, branch):
         retcode, out, err = self.git(repo_name,
                                      'show-ref', '--verify', '--quiet', 'refs/heads/%s' % branch)
-        return retcode == 0        
+        return retcode == 0
 
     def _mark_commit_as_in_use(self, repo_name, commit):
         retcode, out, err = self.git(repo_name, 'branch', 'inuse/%s' % commit, commit)
@@ -462,13 +468,10 @@ class GitSourceCache(object):
             # branch-names at all since we merge all projects encountered into the
             # same repo
             commit = self._resolve_remote_rev(repo_name, repo_url, rev)
-            
+
         if rev is not None:
-            try:
-                self.git_interactive(repo_name, 'fetch', repo_url, rev)
-            except subprocess.CalledProcessError:
-                self.logger.error('failed command: git fetch %s %s' % (repo_url, rev))
-                raise
+            self.checked_git(repo_name, 'fetch', repo_url, rev)
+
         else:
             # when rev is None, fetch all the remote heads; seems like one must
             # do a separate ls-remote...
@@ -476,8 +479,8 @@ class GitSourceCache(object):
             heads = [line.split()[1] for line in out.splitlines() if line.strip()]
             # Fix for https://github.com/hashdist/python-hpcmp2/issues/57
             heads = [x for x in heads if not x.endswith("^{}")]
-            self.git_interactive(repo_name, 'fetch', repo_url, *heads)
-            
+            self.checked_git(repo_name, 'fetch', repo_url, *heads)
+
         if not self._has_commit(repo_name, commit):
             raise SourceNotFoundError('Repository "%s" did not contain commit "%s"' %
                                       (repo_url, commit))
@@ -489,7 +492,7 @@ class GitSourceCache(object):
 
     def unpack(self, type, hash, target_path):
         import tarfile
-        
+
         assert type == 'git'
 
         # We don't want to require supplying a repo name, so for now
@@ -564,11 +567,11 @@ class ArchiveSourceCache(object):
             except urllib2.HTTPError, e:
                 msg = "urllib failed to download (code: %d): %s" % (e.code, url)
                 self.logger.error(msg)
-                raise RuntimeError(msg)
+                raise RemoteFetchError(msg)
             except urllib2.URLError, e:
                 msg = "urllib failed to download (reason: %s): %s" % (e.reason, url)
                 self.logger.error(msg)
-                raise RuntimeError(msg)
+                raise RemoteFetchError(msg)
 
         # Download file to a temporary file within self.packs_path, while hashing
         # it.
@@ -578,7 +581,10 @@ class ArchiveSourceCache(object):
             f = os.fdopen(temp_fd, 'wb')
             tee = HashingWriteStream(hashlib.sha256(), f)
             if use_urllib:
-                progress = ProgressBar(int(stream.headers["Content-Length"]))
+                if 'Content-Length' in stream.headers:
+                    progress = ProgressBar(int(stream.headers["Content-Length"]))
+                else:
+                    progress = None
             try:
                 n = 0
                 while True:
@@ -586,17 +592,19 @@ class ArchiveSourceCache(object):
                     if not chunk: break
                     if use_urllib:
                         n += len(chunk)
-                        progress.update(n)
+                        if progress: progress.update(n)
                     tee.write(chunk)
             finally:
                 stream.close()
                 f.close()
                 if use_urllib:
-                    progress.finish()
-        except:
+                    if progress: progress.finish()
+        except Exception as e:
             # Remove temporary file if there was a failure
             os.unlink(temp_path)
-            raise
+            msg = "Unhandled Exception in Download: %s" % e
+            self.logger.error(msg)
+            raise RemoteFetchError(msg)
 
         if not create_archive_handler(type).verify(temp_path):
             self.logger.error("File downloaded from '%s' is not a valid archive" % url)
@@ -670,7 +678,7 @@ class ArchiveSourceCache(object):
             with file(pack_filename, 'w') as f:
                 hit_pack(files, f)
         return key
-    
+
     def unpack(self, type, hash, target_dir):
         infile = self.open_file(type, hash)
         with infile:
@@ -697,7 +705,7 @@ class ArchiveSourceCache(object):
     #
     def _extract_hit_pack(self, f, key, target_dir):
         files = hit_unpack(f, key)
-        scatter_files(files, target_dir)        
+        scatter_files(files, target_dir)
 
 
 #
@@ -725,7 +733,7 @@ def common_path_prefix(paths):
 
 class TarballHandler(object):
     chunk_size = 16 * 1024
-    
+
     def verify(self, filename):
         import tarfile
         try:
@@ -825,7 +833,7 @@ class ZipHandler(object):
             for info in infolist:
                 info.filename = info.filename[prefix_len:]
                 f.extract(info, target_dir)
-        
+
 archive_ext_to_type = {}
 archive_handler_classes = {}
 archive_types = []
@@ -836,7 +844,7 @@ for cls in [TarGzHandler, TarBz2Handler, TarXzHandler, ZipHandler]:
     archive_types.append(cls.type)
 archive_types = sorted(archive_types)
 
-        
+
 def create_archive_handler(type):
     return archive_handler_classes[type]()
 
@@ -914,7 +922,7 @@ def hit_unpack(stream, key):
     if digest != format_digest(tee):
         raise CorruptSourceCacheError('hit-pack does not match key "%s"' % key)
     return files
-        
+
 def scatter_files(files, target_dir):
     """
     Given a list of filenames and their contents, write them to the file system.
@@ -951,4 +959,3 @@ def silent_unlink(path):
         os.unlink(temp_file)
     except:
         pass
-

--- a/hashdist/core/test/test_source_cache.py
+++ b/hashdist/core/test/test_source_cache.py
@@ -13,7 +13,7 @@ pjoin = os.path.join
 
 from ..source_cache import (ArchiveSourceCache, SourceCache,
         CorruptSourceCacheError, hit_pack, hit_unpack, scatter_files,
-        KeyNotFoundError, SourceNotFoundError, SecurityError)
+        KeyNotFoundError, SourceNotFoundError, SecurityError, RemoteFetchError)
 from ..hasher import Hasher, format_digest
 
 from .utils import temp_dir, working_directory, VERBOSE, logger, assert_raises, MemoryLogger
@@ -177,7 +177,7 @@ def test_curl_errors():
     with temp_source_cache() as sc:
         with assert_raises(ValueError):
             sc.fetch_archive('/tmp/foo/garbage.tar.gz') # malformed, would need file: prefix
-        with assert_raises(RuntimeError):
+        with assert_raises(RemoteFetchError):
             sc.fetch_archive('http://localhost:999/foo.tar.gz')
     
 


### PR DESCRIPTION
- Added retry decorator (used in source_cache.py)
- Slight refactoring of git fetching
- Disabling progress bar if content headers not available
- Friendlier error messages from main for remote fetch errors

Suggested-by: tomspur tomspur@fedoraproject.org
