### PR TITLE
Out-of-profile build support

### DIFF
--- a/hashdist/core/build_tools.py
+++ b/hashdist/core/build_tools.py
@@ -225,25 +225,35 @@ _launcher_script = dedent("""\
     %(arg_assign)s # may be 'arg=...' if there is an argument
     o=`pwd`
 
+    if [ "$HDIST_IN_BUILD" = "yes" ] ; then exec "$i" "$0"%(arg_expr)s"$@"; fi
+
     # Loop to follow chain of links by cd-ing to their
     # directories and calling readlink. $p is current link.
     # After exiting loop, one is in the directory of the real script.
     p="$0"
     while true; do
-        # Must test for whether $p is a link, and we should continue looping
-        # or not, before we change directory.
-        test -L "$p"
-        il=$? # is_link
-        cd `dirname "$p"`
-        pdir=`pwd -P`
-        d="$pdir"
+	# Must test for whether $p is a link, and we should continue looping
+	# or not, before we change directory.
+	test -L "$p"
+	il=$? # is_link
+	cd `dirname "$p"`
+	pdir=`pwd -P`
+	d="$pdir"
 
-        # Loop to cd upwards towards root searching for "artifact.json" file.
-        while [ "$d" != / ]; do
-          [ -e "$d/artifact.json" ]&&cd "$o"&&exec "$d/bin/$i" "$0"%(arg_expr)s"$@"
-          cd ..
-          d=`pwd -P`
-        done
+	# Loop to cd upwards towards root searching for "artifact.json" file.
+	while [ "$d" != / ]; do
+
+	  if [ -e "$d/artifact.json" ] ; then
+	     if [ ! -e "$d/bin/$i" ] ; then
+		echo "Unable to locate needed $i in $p/bin"
+		echo "HashDist profile $d has likely been corrupted, please try rebuilding."
+		exit 127
+	     fi
+	     cd "$o" && exec "$d/bin/$i" "$0"%(arg_expr)s"$@"
+	  fi
+	  cd ..
+	  d=`pwd -P`
+	done
 
         # No is-profile found; 
         cd "$pdir"
@@ -255,6 +265,10 @@ _launcher_script = dedent("""\
     p=`pwd -P`
 
     cd "$o"
+    if [ ! -e "$p/$i" ] ; then
+       echo "Unable to locate needed $i in $p\n"
+       exit 127
+    fi
     exec "$p/$i" "$0"%(arg_expr)s"$@"
     exit 127
 """)

--- a/hashdist/spec/package.py
+++ b/hashdist/spec/package.py
@@ -50,7 +50,7 @@ class PackageSpec(object):
         """
         Return build script (Bash script) that should be run to build package.
         """
-        lines = ['set -e']
+        lines = ['set -e', 'HDIST_IN_BUILD=yes']
         for stage in self.doc['build_stages']:
             lines += ctx.dispatch_build_stage(stage)
         return '\n'.join(lines) + '\n'

--- a/hashdist/spec/tests/test_package.py
+++ b/hashdist/spec/tests/test_package.py
@@ -34,6 +34,7 @@ def test_assemble_stages():
     script = p.assemble_build_script(ctx)
     assert script == dedent("""\
     set -e
+    HDIST_IN_BUILD=yes
     ./configure --with-foo=somevalue
     make
     make install


### PR DESCRIPTION
Many packages rely on the presence of working binaries from other
builds.  This patch supercedes Issue #160 and
fixes https://github.com/hashdist/hashstack2/issues/79,
which prevented the multiline shebang script from correctly resolving an
out-of-profile interpreter.  The shebang script error messages have also
been improved.

Reported-by: Ondrej Certik ondrej.certik@gmail.com
