### PR TITLE
Implicit parameter substitution.

### DIFF
--- a/hashdist/spec/tests/test_utils.py
+++ b/hashdist/spec/tests/test_utils.py
@@ -11,7 +11,6 @@ def test_substitute():
     def check_raises(x):
         with assert_raises(ProfileError):
             utils.substitute_profile_parameters(x, env)
-    yield check_raises, "a{{Ax}}b"
     yield check_noop, "$A$B"
     yield check_noop, "${A}x"
     yield check_noop, "\\${A}x"
@@ -19,3 +18,4 @@ def test_substitute():
     yield check_noop, "${A}\$\${x}"
 
     yield check, "abcb\n\nb", "a{{B}}c{{B}}\n\n{{B}}"
+    yield check, "ab", "a{{Ax}}b"

--- a/hashdist/spec/utils.py
+++ b/hashdist/spec/utils.py
@@ -6,13 +6,12 @@ _STACK_SUBST_RE = re.compile(r'\{\{([^}]*)\}\}')
 def substitute_profile_parameters(s, parameters):
     """
     Substitutes using the syntax ``{{param}}``.
+
+    If {{param}} is undefined, the empty string is returned instead.
     """
     def repl(m):
-        try:
-            return parameters[m.group(1)]
-        except KeyError:
-            raise ProfileError(getattr(s, 'start_mark', None),
-                               'Tried to substitute undefined parameter "%s"' % m.group(1))
+        return parameters.get(m.group(1), '')
+
     return _STACK_SUBST_RE.subn(repl, s)[0]
 
 


### PR DESCRIPTION
This relaxes behavior of parameter substitution, allowing
undefined parameters to be substituted as the empty string.

This allows build profiles to pass parameters down to package
specifications without requiring that every build profile specify
the parameter.
