### PR TITLE
build --profile profile.yaml -> build profile.yaml

### DIFF
--- a/hashdist/cli/frontend_cli.py
+++ b/hashdist/cli/frontend_cli.py
@@ -14,7 +14,7 @@ def add_build_args(ap):
     ap.add_argument('--debug', action='store_true', help='enter interactive debug mode')
 
 def add_profile_args(ap):
-    ap.add_argument('-p', '--profile', default='default.yaml', help='yaml file describing profile to build (default: default.yaml)')
+    ap.add_argument('profile', nargs='?', default='default.yaml', help='yaml file describing profile to build (default: default.yaml)')
 
 def add_develop_args(ap):
     ap.add_argument('-l', '--link', default='absolute', help='Link action: one of [absolute, relative, copy] (default: absolute)')


### PR DESCRIPTION
I type hit build --profile so often it's become muscle memory.
It's inconvenient, and the wrong approach, let's change it!
