### PR TITLE
Undefined parameters (null) are undefined

### DIFF
--- a/hashdist/formats/marked_yaml.py
+++ b/hashdist/formats/marked_yaml.py
@@ -94,6 +94,9 @@ class unicode_node(unicode_node_base):
         return r
 
 class null_node(create_node_class(object, name='null_node')):
+    def __nonzero__(self):
+        return False
+
     def __repr__(self):
         return "null"
 

--- a/hashdist/spec/hook_api.py
+++ b/hashdist/spec/hook_api.py
@@ -65,6 +65,8 @@ class PackageBuildContext(object):
             return self.sub(doc)
         elif isinstance(doc, (int, bool, float, types.NoneType)):
             return doc
+        elif (not doc):
+            return None
         else:
             raise TypeError("unexpected item in documents of type %r: %s" % (type(doc), doc))
 


### PR DESCRIPTION
e.g.

pkgs/petsc.py

```
if stage_args['coptflags']:
    conf_lines.append('COPTFLAGS=%s' % stage_args['coptflags'])
```

If coptflags is not defined in the profile, the condition evaluates to
False.
