### PR TITLE
restore write protection on directories

### DIFF
--- a/hashdist/cli/build_tools_cli.py
+++ b/hashdist/cli/build_tools_cli.py
@@ -244,7 +244,7 @@ class BuildPostprocess(object):
                                     build_store))
 
         if args.write_protect:
-            handlers.append(build_tools.postprocess_write_protect)
+            handlers.append(build_tools.write_protect)
 
         if args.path is None:
             try:
@@ -261,7 +261,8 @@ class BuildPostprocess(object):
                 handler(args.path)
         else:
             for dirpath, dirnames, filenames in os.walk(args.path, topdown=False):
-                for filename in filenames + [dirpath]:
-                    for handler in handlers:
+                for handler in handlers:
+                    for filename in filenames:
                         handler(pjoin(dirpath, filename))
+                    handler(dirpath)
         

--- a/hashdist/core/build_store.py
+++ b/hashdist/core/build_store.py
@@ -149,7 +149,7 @@ from .common import (InvalidBuildSpecError, BuildFailedError,
                      json_formatting_options, SHORT_ARTIFACT_ID_LEN,
                      working_directory)
 from .fileutils import silent_unlink, robust_rmtree, rmtree_up_to, silent_makedirs, gzip_compress, write_protect
-from .fileutils import rmtree_write_protected, atomic_symlink, realpath_to_symlink
+from .fileutils import rmtree_write_protected, atomic_symlink, realpath_to_symlink, allow_writes
 from . import run_job
 
 
@@ -431,9 +431,10 @@ class BuildStore(object):
 
     def serialize_build_spec(self, build_spec, target_dir):
         fname = pjoin(target_dir, 'build.json')
-        with file(fname, 'w') as f:
-            json.dump(build_spec.doc, f, **json_formatting_options)
-            f.write('\n')
+        with allow_writes(target_dir):
+            with file(fname, 'w') as f:
+                json.dump(build_spec.doc, f, **json_formatting_options)
+                f.write('\n')
         write_protect(fname)
 
     def _encode_symlink(self, symlink):
@@ -550,7 +551,7 @@ class ArtifactBuilder(object):
             self.make_artifact_json(artifact_dir)
             self.build_to(artifact_dir, config, keep_build)
         except:
-            shutil.rmtree(artifact_dir)
+            rmtree_write_protected(artifact_dir)
             raise
         return artifact_dir
 
@@ -571,9 +572,10 @@ class ArtifactBuilder(object):
                 self.build_store.serialize_build_spec(self.build_spec, artifact_dir)
 
                 # Create 'id' marker for finished build by writing to _id and then mv to id
-                with open(pjoin(artifact_dir, '_id'), 'w') as f:
-                    f.write('%s\n' % self.build_spec.artifact_id)
-                os.rename(pjoin(artifact_dir, '_id'), pjoin(artifact_dir, 'id'))
+                with allow_writes(artifact_dir):
+                    with open(pjoin(artifact_dir, '_id'), 'w') as f:
+                        f.write('%s\n' % self.build_spec.artifact_id)
+                    os.rename(pjoin(artifact_dir, '_id'), pjoin(artifact_dir, 'id'))
             except:
                 should_keep = (keep_build in ('always', 'error'))
                 raise
@@ -641,9 +643,9 @@ class ArtifactBuilder(object):
             finally:
                 logger.pop_stream()
         log_gz_filename = pjoin(artifact_dir, 'build.log.gz')
-        gzip_compress(pjoin(build_dir, 'build.log'), log_gz_filename)
+        with allow_writes(artifact_dir):
+            gzip_compress(pjoin(build_dir, 'build.log'), log_gz_filename)
         write_protect(log_gz_filename)
-
 
 def unpack_sources(logger, source_cache, doc, target_dir):
     """

--- a/hashdist/core/build_tools.py
+++ b/hashdist/core/build_tools.py
@@ -148,16 +148,6 @@ def postprocess_multiline_shebang(build_store, filename):
         if mod_scriptlines != scriptlines:
             with open(filename, 'w') as f:
                 f.write(''.join(mod_scriptlines))
-        
-
-def postprocess_write_protect(filename):
-    """
-    Write protect files. Leave directories alone because the inability
-    to rm -rf is very annoying.
-    """
-    if not os.path.isfile(filename):
-        return
-    write_protect(filename)
 
 
 #


### PR DESCRIPTION
- @dagss originally put code in that didn't protect directories
- @certik introduced a non-portable fix to add directory protection
- I removed the non-portable code when introducing `develop` functionality.
  (see 9d9f0b728bfc88d4b435b691bd95e3171159f1af )

Now I'm re-adding portable directory protection to protect us from
further foot-shooting.
