### PR TITLE
Better Unicode handling

### DIFF
--- a/hashdist/core/run_job.py
+++ b/hashdist/core/run_job.py
@@ -728,6 +728,7 @@ class CommandTreeExecution(object):
         logger = self.logger
         stdout_fd, stderr_fd = proc.stdout.fileno(), proc.stderr.fileno()
         fds = [stdout_fd, stderr_fd]
+        encoding = sys.stderr.encoding
         for fd in fds: # set O_NONBLOCK
             fcntl.fcntl(fd, fcntl.F_SETFL, fcntl.fcntl(fd, fcntl.F_GETFL) | os.O_NONBLOCK)
 
@@ -760,7 +761,7 @@ class CommandTreeExecution(object):
                         for line in lines:
                             if line[-1] == '\n':
                                 line = line[:-1]
-                            logger.debug(line)
+                            logger.debug(line.decode(encoding))
                     
             if proc.poll() is not None:
                 break

--- a/hashdist/hdist_logging.py
+++ b/hashdist/hdist_logging.py
@@ -143,10 +143,10 @@ class Logger(object):
         heading = colorize(heading, get_log_color(level))
         for stream, is_raw in self.streams:
             if is_raw:
-                stream.write(msg + "\n")
+                stream.write(('%s\n' % (msg)).encode('ascii', 'ignore'))
                 stream.flush()
             elif level >= self.level:
-                stream.write('%s%s\n' % (heading, msg))
+                stream.write(u'%s%s\n' % (heading, msg))
         if level >= ERROR:
             self.set_error_occurred(True)
 


### PR DESCRIPTION
This fixes a long-standing issue on Cygwin where Unicode-encoded error
messages from stderr were unable to be written to the ASCII-encoded
build log.  The messages are now explicitly converted to ASCII with
untranslatable characters ignored.
