### PR TITLE
Handle case where encoding is not set

### DIFF
--- a/hashdist/core/run_job.py
+++ b/hashdist/core/run_job.py
@@ -761,8 +761,10 @@ class CommandTreeExecution(object):
                         for line in lines:
                             if line[-1] == '\n':
                                 line = line[:-1]
-                            logger.debug(line.decode(encoding))
-                    
+                            if encoding:
+                                logger.debug(line.decode(encoding))
+                            else:
+                                logger.debug(line)
             if proc.poll() is not None:
                 break
         for buf in buffers.values():


### PR DESCRIPTION
This was turned up by the post-merge tests in Protues: https://github.com/hashdist/hashdist/pull/228
