### PR TITLE
Improve support for hit develop -l copy

### DIFF
--- a/hashdist/core/fileutils.py
+++ b/hashdist/core/fileutils.py
@@ -1,5 +1,6 @@
 import os
 import errno
+import filecmp
 import shutil
 import time
 import gzip
@@ -8,9 +9,15 @@ from contextlib import closing
 
 def silent_copy(src, dst):
     try:
-        shutil.copy(src, dst)
+        if os.path.isdir(src):
+            shutil.copytree(src, dst)
+        else:
+            shutil.copy(src, dst)
     except OSError, e:
         if e.errno != errno.EEXIST:
+            raise
+    except IOError, e:
+        if not filecmp.cmp(src, dst):
             raise
 
 def silent_relative_symlink(src, dst):

--- a/hashdist/spec/package.py
+++ b/hashdist/spec/package.py
@@ -109,10 +109,11 @@ class PackageSpec(object):
                               "select": select})
             elif 'launcher' in in_stage:
                 select = substitute_profile_parameters(in_stage["launcher"], parameters)
-                rules.append({"action": "launcher",
-                              "select": "${%s_DIR}/%s" % (ref, select),
-                              "prefix": "${%s_DIR}" % ref,
-                              "target": target})
+                if link_type != 'copy':
+                    rules.append({"action": "launcher",
+                                  "select": "${%s_DIR}/%s" % (ref, select),
+                                  "prefix": "${%s_DIR}" % ref,
+                                  "target": target})
             elif 'copy' in in_stage:
                 select = substitute_profile_parameters(in_stage["copy"], parameters)
                 rules.append({"action": "copy",


### PR DESCRIPTION
We use hit develop -l copy to build a complete profile in-place that is
suitable for archiving or redistribution.

This improves support for profiles that use launcher by silently
ignoring requests to launchify executables, and allowing copy requests
to work for directories as well.
