### PR TITLE
Speedup profile creation

### DIFF
--- a/hashdist/core/ant_glob.py
+++ b/hashdist/core/ant_glob.py
@@ -122,8 +122,4 @@ def has_permission(path):
     """
     Returns True if we have 'listdir' permissions. False otherwise.
     """
-    try:
-        l = os.listdir(path)
-        return True
-    except OSError:
-        return False
+    return os.access(path, os.R_OK)


### PR DESCRIPTION
Use os.access() to test if the directory can be read. The `listdir` approach is
very slow.

Fixes #237.
