### PR TITLE
Improve the output of `hit fetch`

### DIFF
--- a/hashdist/cli/source_cache_cli.py
+++ b/hashdist/cli/source_cache_cli.py
@@ -79,8 +79,9 @@ class Fetch(object):
         args.url = as_url(args.url)
         key = store.fetch_archive(args.url, args.type)
         sys.stderr.write('\n')
-        sys.stdout.write('url: %s\n' % args.url)
-        sys.stdout.write('key: %s\n' % key)
+        sys.stdout.write('sources:\n')
+        sys.stdout.write('- url: %s\n' % args.url)
+        sys.stdout.write('  key: %s\n' % key)
         if args.key and key != args.key:
             sys.stderr.write('Keys did not match\n')
             return 2


### PR DESCRIPTION
Previously:

```
$ hit fetch http://llvm.org/releases/3.4/libcxx-3.4.src.tar.gz
Downloading http://llvm.org/releases/3.4/libcxx-3.4.src.tar.gz...
Downloading 'http://llvm.org/releases/3.4/libcxx-3.4.src.tar.gz'
[=========================] 100.0% (1.3MB of 1.3MB) 2.418MB/s ETA 0s

tar.gz:xwpsaatz6dvrt7bi5uwz2yd57u4ofz6z
```

Now:

```
$ hit fetch http://llvm.org/releases/3.4/libcxx-3.4.src.tar.gz
Downloading http://llvm.org/releases/3.4/libcxx-3.4.src.tar.gz...
Downloading 'http://llvm.org/releases/3.4/libcxx-3.4.src.tar.gz'
[=========================] 100.0% (1.3MB of 1.3MB) 3.022MB/s ETA 0s

url: http://llvm.org/releases/3.4/libcxx-3.4.src.tar.gz
key: tar.gz:xwpsaatz6dvrt7bi5uwz2yd57u4ofz6z
```

The output can now be copy & pasted into the package.yaml
