### PR TITLE
Improve config.yaml validation

### DIFF
--- a/hashdist/cli/manage_store_cli.py
+++ b/hashdist/cli/manage_store_cli.py
@@ -4,7 +4,13 @@ import shutil
 from os.path import join as pjoin, exists as pexists
 from textwrap import dedent
 
-from ..formats.config import DEFAULT_CONFIG_FILENAME_REPR, DEFAULT_CONFIG_FILENAME, get_config_example_filename
+from ..formats.config import (
+    DEFAULT_STORE_DIR,
+    DEFAULT_CONFIG_DIRS,
+    DEFAULT_CONFIG_FILENAME_REPR,
+    DEFAULT_CONFIG_FILENAME,
+    get_config_example_filename
+)
 from .main import register_subcommand
 
 @register_subcommand
@@ -22,17 +28,34 @@ class InitHome(object):
 
     @staticmethod
     def run(ctx, args):
-        store_dir = os.path.expanduser('~/.hashdist')
-        for x in [DEFAULT_CONFIG_FILENAME, store_dir]:
-            if pexists(x):
-                ctx.logger.error('%s already exists, aborting\n' % x)
+        for path in [DEFAULT_STORE_DIR, DEFAULT_CONFIG_FILENAME]:
+            if pexists(path):
+                ctx.logger.error('%s already exists, aborting\n' % path)
                 return 2
 
-        for x in ['ba', 'bld', 'src', 'db', 'cache', 'gcroots']:
-            os.makedirs(pjoin(store_dir, x))
-        sys.stdout.write('Directory %s created.\n' % store_dir)
+        for path in DEFAULT_CONFIG_DIRS:
+            os.makedirs(pjoin(DEFAULT_STORE_DIR, path))
+            sys.stdout.write('Directory %s created.\n' % path)
         shutil.copyfile(get_config_example_filename(), DEFAULT_CONFIG_FILENAME)
         sys.stdout.write('Default configuration file %s written.\n' % DEFAULT_CONFIG_FILENAME)
+
+@register_subcommand
+class SelfCheck(object):
+    """
+    Verifies the consistency of a HashDist configuration file.
+    """
+    command = 'self-check'
+
+    @staticmethod
+    def setup(ap):
+        pass
+
+    @staticmethod
+    def run(ctx, args):
+        # This is done implicitly when the context is loaded.
+        ctx.get_config()
+        ctx.logger.info('The configuration now appears to be consistent.')
+
 
 @register_subcommand
 class ClearSources(object):

--- a/hashdist/formats/config.py
+++ b/hashdist/formats/config.py
@@ -8,8 +8,10 @@ from os.path import join as pjoin
 from ..deps import jsonschema
 from .marked_yaml import (load_yaml_from_file, validate_yaml, ValidationError)
 
-DEFAULT_CONFIG_FILENAME_REPR = '~/.hashdist/config.yaml'
+DEFAULT_STORE_DIR = os.path.expanduser('~/.hashdist')
+DEFAULT_CONFIG_FILENAME_REPR = os.path.join(DEFAULT_STORE_DIR, 'config.yaml')
 DEFAULT_CONFIG_FILENAME = os.path.expanduser(DEFAULT_CONFIG_FILENAME_REPR)
+DEFAULT_CONFIG_DIRS = ('ba', 'bld', 'src', 'db', 'cache', 'gcroots')
 
 config_schema = {
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -48,26 +50,36 @@ config_schema = {
     "required": ["build_stores", "source_caches", "build_temp", "cache", "gc_roots"]
 }
 
+def _ensure_dir(path, logger):
+    if not os.path.isdir(path):
+        logger.info('%s does not exist, creating it.' % path)
+        os.makedirs(path)
+    return path
+
 def _make_abs(cwd, path):
     if not os.path.isabs(path):
         return os.path.realpath(os.path.join(cwd, path))
     else:
         return path
 
-def load_config_file(filename):
+def load_config_file(filename, logger):
+    """
+    Load hashdist config.yaml file, validates it, and creates missing directories.
+    """
+
     basedir = os.path.dirname(os.path.realpath(filename))
     doc = load_yaml_from_file(filename)
     validate_yaml(doc, config_schema)
     for entry in doc['build_stores']:
-        entry['dir'] = _make_abs(basedir, entry['dir'])
+        entry['dir'] = _ensure_dir(_make_abs(basedir, entry['dir']), logger)
 
     for entry in doc['source_caches']:
         if sum(['url' in entry, 'dir' in entry]) != 1:
             raise ValidationError(entry.start_mark, 'Exactly one of "url" and "dir" must be specified')
         if 'dir' in entry:
-            entry['dir'] = _make_abs(basedir, entry['dir'])
+            entry['dir'] = _ensure_dir(_make_abs(basedir, entry['dir']), logger)
     for key in ['build_temp', 'cache', 'gc_roots']:
-        doc[key] = _make_abs(basedir, doc[key])
+        doc[key] = _ensure_dir(_make_abs(basedir, doc[key]), logger)
     return doc
 
 def get_config_example_filename():

--- a/hashdist/formats/tests/test_config.py
+++ b/hashdist/formats/tests/test_config.py
@@ -4,7 +4,7 @@ from os.path import join as pjoin
 from textwrap import dedent
 from .. import config
 from .. import marked_yaml
-from ...core.test.utils import temp_working_dir_fixture, working_directory, dump, assert_raises
+from ...core.test.utils import temp_working_dir_fixture, working_directory, dump, logger
 
 
 
@@ -20,7 +20,7 @@ def test_schema_error(d):
         gc_roots: a
     """)
     try:
-        cfg = config.load_config_file('config.yaml')
+        cfg = config.load_config_file('config.yaml', logger)
     except marked_yaml.ValidationError as e:
         assert str(e) == "config.yaml, line 3: {'a': 3} is not of type 'array'"
     else:
@@ -39,7 +39,7 @@ def test_load_config(d):
         gc_roots: ./gcroots
     """)
     with working_directory('/'):
-        c = config.load_config_file(pjoin(d, 'config.yaml'))
+        c = config.load_config_file(pjoin(d, 'config.yaml'), logger)
 
     assert c == {
         'build_stores': [{'dir': pjoin(d, 'ba')}],


### PR DESCRIPTION
Add hit self-check command

This should automatically be run any time a configuration is loaded,
similar to the way init-home is always run the first time hit is used.
