### PR TITLE
Add default profiles and use flags

### DIFF
--- a/hashdist/cli/frontend_cli.py
+++ b/hashdist/cli/frontend_cli.py
@@ -32,7 +32,7 @@ class ProfileFrontendBase(object):
         self.source_cache = SourceCache.create_from_config(ctx.get_config(), ctx.logger)
         self.build_store = BuildStore.create_from_config(ctx.get_config(), ctx.logger)
         self.checkouts = TemporarySourceCheckouts(self.source_cache)
-        self.profile = load_profile(self.checkouts, args.profile)
+        self.profile = load_profile(self.checkouts, args.profile, ctx.get_default_profile())
         self.builder = ProfileBuilder(self.ctx.logger, self.source_cache, self.build_store, self.profile)
 
     @classmethod

--- a/hashdist/cli/main.py
+++ b/hashdist/cli/main.py
@@ -82,6 +82,10 @@ class HashdistCommandContext(object):
             self._ensure_config()
         return self._config
 
+    def get_default_profile(self):
+        config = self.get_config()
+        return config.get('default_profile', {})
+
     def error(self, msg):
         self.argparser.error(msg)
 

--- a/hashdist/formats/config.example.cygwin.yaml
+++ b/hashdist/formats/config.example.cygwin.yaml
@@ -1,0 +1,74 @@
+## Configuration file for Hashdist
+
+## All relative paths are relative to the directory containing this
+## configuration file.
+
+## Where to store the built software
+
+build_stores:
+ - dir: ./bld
+
+
+## Location where temporary directories for building software are created.
+## Such directories are by default removed again once the build is done.
+
+build_temp: ./tmp
+
+
+## Locations of downloaded tarballs and git repositories.  A location
+## can either be a local filesystem, or a URL to an online, read-only
+## mirror. Only the first location, which should be a local directory,
+## will be written to.
+
+source_caches:
+ - dir: ./src
+## For additional source cache mirror:
+## - url: https://some.server.org/hashdist/src
+
+
+## The cache directory is used for misc. caching (e.g., probing of host
+## system).  The contents can always be wiped without resulting in rebuilds.
+
+cache: ./cache
+
+## The roots directory contains links to (links to) profiles. Anything
+## pointed to through here will not be deleted when garbage-collected.
+
+gc_roots: ./gcroots
+
+## The default_profile contains profile parameters that are populated by
+## default on all builds.  Typically, this is where you would put information
+## specific to your operating system.
+
+default_profile:
+  package_dirs:
+    - pkgs
+    - base
+
+  hook_import_dirs:
+    - base
+
+  parameters:
+    platform: cygwin
+    pyver: '2.7'  # as in used in lib/pythonX.Y/site-packages
+    python_site_packages_rel: 'lib/python2.7/site-packages'
+
+    BASH: /bin/bash
+    PATH: /usr/bin:/bin:/usr/sbin:/sbin
+    HOST_MPICC: /usr/bin/mpicc
+    HOST_MPICXX: /usr/bin/mpic++
+    HOST_MPIF77: /usr/bin/mpif77
+    HOST_MPIF90: /usr/bin/mpif90
+    HOST_MPIEXEC: /usr/bin/mpiexec
+    HOST_CMAKE: /usr/bin/cmake
+    HOST_PYTHON: /usr/bin/python
+    HOST_PKG_CONFIG_EXECUTABLE: /usr/bin/pkgconfig
+    HOST_SWIG_EXECUTABLE: /usr/bin/swig
+
+    PROLOGUE: |
+
+  default_use:
+    blas: host-blas
+    cmake: host-cmake
+    freetype: host-freetype
+    mpi: host-mpi

--- a/hashdist/formats/config.example.darwin.yaml
+++ b/hashdist/formats/config.example.darwin.yaml
@@ -1,0 +1,63 @@
+## Configuration file for Hashdist
+
+## All relative paths are relative to the directory containing this
+## configuration file.
+
+## Where to store the built software
+
+build_stores:
+ - dir: ./bld
+
+
+## Location where temporary directories for building software are created.
+## Such directories are by default removed again once the build is done.
+
+build_temp: ./tmp
+
+
+## Locations of downloaded tarballs and git repositories.  A location
+## can either be a local filesystem, or a URL to an online, read-only
+## mirror. Only the first location, which should be a local directory,
+## will be written to.
+
+source_caches:
+ - dir: ./src
+## For additional source cache mirror:
+## - url: https://some.server.org/hashdist/src
+
+
+## The cache directory is used for misc. caching (e.g., probing of host
+## system).  The contents can always be wiped without resulting in rebuilds.
+
+cache: ./cache
+
+## The roots directory contains links to (links to) profiles. Anything
+## pointed to through here will not be deleted when garbage-collected.
+
+gc_roots: ./gcroots
+
+## The default_profile contains profile parameters that are populated by
+## default on all builds.  Typically, this is where you would put information
+## specific to your operating system.
+
+default_profile:
+  package_dirs:
+    - pkgs
+    - base
+
+  hook_import_dirs:
+    - base
+
+  parameters:
+    platform: darwin
+    pyver: '2.7'  # as in used in lib/pythonX.Y/site-packages
+    python_site_packages_rel: 'lib/python2.7/site-packages'
+
+    BASH: /bin/bash
+    PATH: /usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin
+    PROLOGUE: |
+      export MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion | sed "s/\(10.[0-9]\).*/\1/")
+
+  default_use:
+    blas: host-osx-framework-accelerate
+    lapack: host-osx-framework-accelerate

--- a/hashdist/formats/config.example.linux2.yaml
+++ b/hashdist/formats/config.example.linux2.yaml
@@ -35,3 +35,27 @@ cache: ./cache
 ## pointed to through here will not be deleted when garbage-collected.
 
 gc_roots: ./gcroots
+
+## The default_profile contains profile parameters that are populated by
+## default on all builds.  Typically, this is where you would put information
+## specific to your operating system.
+
+default_profile:
+  package_dirs:
+    - pkgs
+    - base
+
+  hook_import_dirs:
+    - base
+
+  parameters:
+    platform: linux # more correct than linux2
+    pyver: '2.7'  # as in used in lib/pythonX.Y/site-packages
+    python_site_packages_rel: 'lib/python2.7/site-packages'
+
+    BASH: /bin/bash
+    PATH: /usr/bin:/bin:/usr/sbin:/sbin
+    PROLOGUE: |
+
+  default_use:
+    blas: host-blas

--- a/hashdist/formats/config.py
+++ b/hashdist/formats/config.py
@@ -4,8 +4,8 @@ Handles reading the Hashdist configuration file. By default this is
 """
 
 import os
+import sys
 from os.path import join as pjoin
-from ..deps import jsonschema
 from .marked_yaml import (load_yaml_from_file, validate_yaml, ValidationError)
 
 DEFAULT_STORE_DIR = os.path.expanduser('~/.hashdist')
@@ -83,4 +83,7 @@ def load_config_file(filename, logger):
     return doc
 
 def get_config_example_filename():
-    return pjoin(os.path.dirname(__file__), 'config.example.yaml')
+    config_path = pjoin(os.path.dirname(__file__), 'config.example.' + sys.platform + '.yaml')
+    if not os.path.isfile(config_path):
+        raise NotImplementedError('No default configuration exists for platform: %s' % sys.platform)
+    return config_path

--- a/hashdist/formats/tests/test_config.py
+++ b/hashdist/formats/tests/test_config.py
@@ -37,6 +37,11 @@ def test_load_config(d):
         - url: http://server.com/source_cache
         cache: ./cache
         gc_roots: ./gcroots
+        default_profile:
+          parameters:
+            platform: darwin
+          default_use:
+            blas: host-osx-framework-accelerate
     """)
     with working_directory('/'):
         c = config.load_config_file(pjoin(d, 'config.yaml'), logger)
@@ -47,4 +52,6 @@ def test_load_config(d):
         'cache': pjoin(d, 'cache'),
         'gc_roots': pjoin(d, 'gcroots'),
         'source_caches': [{'dir': pjoin(d, 'src')},
-                          {'url': 'http://server.com/source_cache'}]}
+                          {'url': 'http://server.com/source_cache'}],
+        'default_profile': {'parameters': {'platform': 'darwin'},
+                            'default_use': {'blas': 'host-osx-framework-accelerate'}}}

--- a/hashdist/spec/builder.py
+++ b/hashdist/spec/builder.py
@@ -38,7 +38,8 @@ class ProfileBuilder(object):
                     raise ProfileError(pkgname, 'dependency cycle between packages, including package "%s"' % pkgname)
                 visiting.add(pkgname)
                 settings = self.profile.packages.get(pkgname, {})
-                use = settings.get('use', pkgname)
+                default_use = self.profile.default_use.get(pkgname, pkgname)
+                use = settings.get('use', default_use)
                 spec = package.PackageSpec.load(self.profile, use)
                 self._package_specs[pkgname] = spec
                 for dep in spec.build_deps + spec.run_deps:


### PR DESCRIPTION
Enable the hashdist config file to specify a default profile that
is inherited by all profiles.  By default, a few common parameters such
as platform are set.

Also, added a new "default_use" section to profiles.  This specifies a
preference for how to resolve common packages.  The most common example
is the blas library, which uses a host blas installation on Linux or
Cygwin, but requires the Accelerate framework on OS X.

Finally, the default platform name for Darwin is now darwin, and the
default platform name for Cygwin is now cygwin.  The default platform
name of Linux has not changed.
