### PR TITLE
Fix test failures on Fedora

### DIFF
--- a/hashdist/cli/test/test_build_tools.py
+++ b/hashdist/cli/test/test_build_tools.py
@@ -42,6 +42,6 @@ def test_symlinks():
         env = dict(os.environ)
         env['FOO'] = 'foo'
         hit('create-links', '--key=section1/section2', 'build.json', env=env)
-        assert os.path.realpath('foo') == '/bin/ls'
-        assert os.path.realpath('bar/bin/ls') == '/bin/ls'
+        assert os.path.realpath('foo') == os.path.realpath('/bin/ls')
+        assert os.path.realpath('bar/bin/ls') == os.path.realpath('/bin/ls')
 

--- a/hashdist/core/links.py
+++ b/hashdist/core/links.py
@@ -33,10 +33,11 @@ happens.
 
 
 **action**:
-  One of "absolute_symlink", "relative_symlink", "copy", "exclude",
-  "launcher". Other types may be added later.
+  One of "symlink", "absolute_symlink", "relative_symlink", "copy",
+  "exclude", "launcher". Other types may be added later.
 
-  * *absolute_symlink* creates absolute symlinks
+  * *absolute_symlink* creates absolute symlinks. Just *symlink* is an
+    alias for absolute symlink.
   * *relative_symlink* creates relative symlinks
   * *copy* copies contents and mode (``shutil.copy``)
   * *exclude* makes sure matching files are not considered in rules below
@@ -68,8 +69,6 @@ happens.
 
 **overwrite**:
   If present and `True`, overwrite target.
-
-
 """
 
 import sys

--- a/hashdist/core/test/test_hit_recipe.py
+++ b/hashdist/core/test/test_hit_recipe.py
@@ -36,6 +36,6 @@ def test_hit_cli_artifact(tempdir, sc, bldr, config):
         }
     virtuals = {'virtual:hit': hit_id}
     artifact_id, path = bldr.ensure_present(spec, config, virtuals)
-    assert os.path.realpath(pjoin(path, 'bin', 'cp')) == '/bin/cp'
+    assert os.path.realpath(pjoin(path, 'bin', 'cp')) == os.path.realpath('/bin/cp')
 
 


### PR DESCRIPTION
There, /bin/ls and /usr/bin/ls are hardlinked. Python's realpath
returns the latter. Obvious fix is to only compare realpaths, never
realpath with what you think the path is.
