### PR TITLE
hit fetch: put the hash first, url second

### DIFF
--- a/hashdist/cli/source_cache_cli.py
+++ b/hashdist/cli/source_cache_cli.py
@@ -80,8 +80,8 @@ class Fetch(object):
         key = store.fetch_archive(args.url, args.type)
         sys.stderr.write('\n')
         sys.stdout.write('sources:\n')
-        sys.stdout.write('- url: %s\n' % args.url)
-        sys.stdout.write('  key: %s\n' % key)
+        sys.stdout.write('- key: %s\n' % key)
+        sys.stdout.write('  url: %s\n' % args.url)
         if args.key and key != args.key:
             sys.stderr.write('Keys did not match\n')
             return 2


### PR DESCRIPTION
The hash is the main object that identifies the source code. The url is only
auxiliary to help `hit` download it (if it is not in the source cache) and it
can change.
