### PR TITLE
Make rmtree() more robust

### DIFF
--- a/hashdist/core/fileutils.py
+++ b/hashdist/core/fileutils.py
@@ -64,7 +64,7 @@ def silent_unlink(path):
         if e.errno != errno.ENOENT:
             raise
 
-def robust_rmtree(path, logger=None, max_retries=5):
+def robust_rmtree(path, logger=None, max_retries=6):
     """Robustly tries to delete paths.
 
     Retries several times (with increasing delays) if an OSError


### PR DESCRIPTION
I noticed that on some clusters, if you watch the build log using `tail -f ...`, then it refuses to delete the tree (due to some NFS handles). The previous loop was too quick to do anything about it, so now it has exponential increase in time, which give the user enough time to exit any `tail -f ...` sessions.
