### PR TITLE
Convert 'Hashdist' to the canonical 'HashDist' capitalization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - python: 3.3
 before_install:
   - git config --global user.email "hashdist@h.com";
-    git config --global user.name "Hashdist"
+    git config --global user.name "HashDist"
 script:
   - VERBOSE=1 nosetests -v -s
 branches:

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -3,7 +3,7 @@ Overview
 
 There are 3 licenses:
 
- * Hashdist: BSD 3-clause
+ * HashDist: BSD 3-clause
  * jsonschema: MIT
  * pyyaml: MIT
  * sh: MIT
@@ -14,7 +14,7 @@ The licenses for each component are copied verbatim below.
 
 
 ##################################################################
-# Hashdist                                                       #
+# HashDist                                                       #
 ##################################################################
 
 Copyright (c) 2012, Dag Sverre Seljebotn and Ondrej Certik
@@ -35,7 +35,7 @@ met:
    distribution.
 
  - Neither the name of Dag Sverre Seljebotn nor the names of other
-   Hashdist contributors may be used to endorse or promote products
+   HashDist contributors may be used to endorse or promote products
    derived from this software without specific prior written
    permission.
 

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-Hashdist
+HashDist
 ========
 
 **Home Page**:
@@ -26,7 +26,7 @@ Hashdist
     Andy Terrel
 
 **Funding:**
-    Hashdist is partially funded by the International Research Office,
+    HashDist is partially funded by the International Research Office,
     US Army Engineer Research and Development Center, BAA contract
     W911NF-12-1-0604
 

--- a/bin/hit-check-libs
+++ b/bin/hit-check-libs
@@ -16,7 +16,7 @@ except ImportError:
     from hashdist.deps import argparse
 
 from hashdist.hdist_logging import Logger
-from hashdist.cli.main import HashdistCommandContext
+from hashdist.cli.main import HashDistCommandContext
 from hashdist.core import BuildStore
 from hashdist.formats.config import (DEFAULT_CONFIG_FILENAME_REPR,
         DEFAULT_CONFIG_FILENAME)
@@ -139,7 +139,7 @@ def main():
     env = os.environ
     logger = Logger()
     profile_path = args.profile
-    ctx = HashdistCommandContext(parser, subcmd_parsers, sys.stdout,
+    ctx = HashDistCommandContext(parser, subcmd_parsers, sys.stdout,
             args.config_file, env, logger)
     build_store = BuildStore.create_from_config(ctx.get_config(), logger)
     print("Checking libs in '%s'..." % profile_path)

--- a/doc/source/build_spec.rst
+++ b/doc/source/build_spec.rst
@@ -4,7 +4,7 @@ Build specifications and artifacts
 The build spec (``build.json``)
 -------------------------------
 
-The heart of Hashdist are *build specs*, JSON documents that describes
+The heart of HashDist are *build specs*, JSON documents that describes
 everything that goes into a build: the source code to use, the build
 environment, the build commands.
 
@@ -75,7 +75,7 @@ or the hash::
     files themselves; they are simply the *API for the build artifact
     store*. It is the responsibility of distributions such as
     *python-hpcmp* to properly generate build specifications for
-    Hashdist in a user-friendly manner.
+    HashDist in a user-friendly manner.
 
 
 Build artifacts
@@ -86,9 +86,9 @@ prefix-style directory containing one library/program only, i.e.,
 typical subdirectories are ``bin``, ``include``, ``lib`` and so on.
 The build artifact should ideally be in a relocatable form that can
 be moved around or packed and distributed to another computer (see
-:doc:`building`), although Hashdist does not enforce this.
+:doc:`building`), although HashDist does not enforce this.
 
-A Hashdist artifact ID has the form ``name/hash``, e.g.,
+A HashDist artifact ID has the form ``name/hash``, e.g.,
 ``zlib/4niostz3iktlg67najtxuwwgss5vl6k4``. For the artifact paths on
 disk, a shortened form (4-char hash) is used to make things more
 friendly to the human user. If there is a collision, the length is
@@ -167,7 +167,7 @@ Discussion
 Safety of the shortened IDs
 '''''''''''''''''''''''''''
 
-Hashdist will never use these to resolve build artifacts, so collision
+HashDist will never use these to resolve build artifacts, so collision
 problems come in two forms:
 
 First, automatically finding the list of run-time dependencies from

--- a/doc/source/building.rst
+++ b/doc/source/building.rst
@@ -1,8 +1,8 @@
 Guidelines for packaging/building
 =================================
 
-Hashdist can be used to build software in many ways. This document
-describes what the Hashdist authors recommend and the helper tools
+HashDist can be used to build software in many ways. This document
+describes what the HashDist authors recommend and the helper tools
 available for post-processing.
 
 Principles

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -41,7 +41,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Hashdist'
+project = u'HashDist'
 copyright = u'2012'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -168,7 +168,7 @@ pygments_style = 'sphinx'
 #html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'Hashdistdoc'
+htmlhelp_basename = 'HashDistDoc'
 
 
 # -- Options for LaTeX output --------------------------------------------------
@@ -182,8 +182,8 @@ htmlhelp_basename = 'Hashdistdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'Hashdist.tex', u'Hashdist Documentation',
-   u'Hashdist team', 'manual'),
+  ('index', 'HashDist.tex', u'HashDist Documentation',
+   u'HashDist team', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -215,6 +215,6 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'hashdist', u'Hashdist Documentation',
-     [u'Hashdist team'], 1)
+    ('index', 'hashdist', u'HashDist Documentation',
+     [u'HashDist team'], 1)
 ]

--- a/doc/source/devguide.rst
+++ b/doc/source/devguide.rst
@@ -7,7 +7,7 @@ Terminology
 -----------
 
 **Distribution**:
-    An end-user software distribution that makes use of Hashdist
+    An end-user software distribution that makes use of HashDist
     under the hood, e.g., python-hpcmp
 
 **Artifact**:
@@ -22,7 +22,7 @@ Terminology
 **Package**:
     Used in the loose sense; a program/library, e.g., NumPy, Python etc.; 
     what is **not** meant is a specific package format like ``.spkg``, ``.egg``
-    and so on (which is left undefined in the bottom two Hashdist layers)
+    and so on (which is left undefined in the bottom two HashDist layers)
 
 Design principles
 -----------------
@@ -38,7 +38,7 @@ Design principles
  * However, implementations of those protocols are currently kept as
    simple as possible.
 
- * Hashdist is a language-neutral solution; Python is the
+ * HashDist is a language-neutral solution; Python is the
    implementation language chosen but the core tools can (in theory)
    be rewritten in C or Ruby without the users noticing any difference
 
@@ -51,14 +51,14 @@ Design principles
 Powerusers' guide, layer by layer
 ---------------------------------
 
-Hashdist consists of two (eventually perhaps three) layers. The idea
+HashDist consists of two (eventually perhaps three) layers. The idea
 is to provide something useful for as many as possible. If a
 distribution only uses the the *core layer* (or even only some of the
 components within it) it can keep on mostly as before, but get a
 performance boost from the caching aspect.  If the distribution wants
-to buy into the greater Hashdist vision, it can use the *profile
+to buy into the greater HashDist vision, it can use the *profile
 specification layer*.  Finally, for end-users, a final user-interface
-layer is needed to make things friendly.  Here Hashdist
+layer is needed to make things friendly.  Here HashDist
 will probably remain silent for some time, but some standards,
 best practices and utilities may emerge. For now, a user interface ideas section is
 included below.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,4 +1,4 @@
-Welcome to the Hashdist documentation
+Welcome to the HashDist documentation
 =====================================
 
 These documents are a work in progress. Some may be out of date. Please `file an
@@ -6,7 +6,7 @@ issue`_ if the instructions appear to be incorrect.
 
 .. _file an issue: https://github.com/hashdist/hashdist/issues
 
-Working with Hashdist
+Working with HashDist
 ---------------------
 
 .. toctree::

--- a/doc/source/plans/core.rst
+++ b/doc/source/plans/core.rst
@@ -1,4 +1,4 @@
-Hashdist core components
+HashDist core components
 ========================
 
 Source store
@@ -224,7 +224,7 @@ Sandboxing
 By setting ``LD_PRELOAD`` it is possible to override ``libc.so`` and
 filter all filesystem calls in order to create a sandbox and make sure
 that the build does not read from ``/usr`` (or anywhere outside the
-Hashdist store, except through symlinks), which would indicate that
+HashDist store, except through symlinks), which would indicate that
 the build reaches out to pull stuff it shouldn't. The Grand Unified
 Builder (GUB) takes this approach.
 

--- a/doc/source/plans/index.rst
+++ b/doc/source/plans/index.rst
@@ -1,4 +1,4 @@
-Plans for Hashdist
+Plans for HashDist
 ==================
 
 

--- a/doc/source/plans/installing.rst
+++ b/doc/source/plans/installing.rst
@@ -1,28 +1,28 @@
-Installing Hashdist for use in software distributions
+Installing HashDist for use in software distributions
 =====================================================
 
 Dependencies
 ------------
 
-Hashdist depends on Python 2.6+.
+HashDist depends on Python 2.6+.
 
 A bootstrap script should be made to facilitate installation everywhere...
 
 Bundling vs. sharing
 --------------------
 
-Hashdist (by which we mean both the library/programs and the source
+HashDist (by which we mean both the library/programs and the source
 and build artifact directories on disk) can either be shared between
 distributions or isolated; thus one may have build artifacts
 in ``~/.hashdist`` which are shared between PyHPC and QSnake, while
-Sage has its own Hashdist store in ``~/path/to/sage/store``.
+Sage has its own HashDist store in ``~/path/to/sage/store``.
 
 .. note::
     
-    The main point of sharing Hashdist is actually to share it
+    The main point of sharing HashDist is actually to share it
     between different versions of the same distribution; i.e., two
     different QSnake versions may be located in different paths on disk,
-    but if they use the global Hashdist they will share the build
+    but if they use the global HashDist they will share the build
     artifacts they have in common.
 
     Another advantage is simply sharing the source store among
@@ -30,10 +30,10 @@ Sage has its own Hashdist store in ``~/path/to/sage/store``.
     and git repos.
 
 
-Managing conflicting Hashdist installations
+Managing conflicting HashDist installations
 -------------------------------------------
 
-By default, Hashdist core tools are exposed through the ``hit``
+By default, HashDist core tools are exposed through the ``hit``
 command and the ``hashdist`` Python package. It is configured through
 ``~/.hitconfig``::
 
@@ -49,7 +49,7 @@ command and the ``hashdist`` Python package. It is configured through
 
     <...>
 
-If a software distribution bundles its own isolated Hashdist
+If a software distribution bundles its own isolated HashDist
 environment then the ``hit`` command should be rebranded (e.g.,
 ``qsnake-hit``), and it should read a different configuration
 file. Similarly, the Python package should be rebranded (e.g.,
@@ -70,11 +70,11 @@ read ``~/.hitconfig`` and then launch a newer version of
 ``hit``. (However, ``qsnake-hit`` is free to behave however it
 likes.)
 
-The best way of distributing Hashdist is in fact to get it through the
+The best way of distributing HashDist is in fact to get it through the
 operating system package manager. In that case, the `hit` key in ``~/.hitconfig``
 will point to ``/usr/bin/hit``. Alternatively, a
 bootstrapping solution is provided and recommended which make sure that each
-distribution using a non-rebranded Hashdist use the same one.
+distribution using a non-rebranded HashDist use the same one.
 
 
 

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -1,4 +1,4 @@
-Hashdist API reference
+HashDist API reference
 ----------------------
 
 

--- a/doc/source/specs.rst
+++ b/doc/source/specs.rst
@@ -1,14 +1,14 @@
-Specifying a Hashdist software profile
+Specifying a HashDist software profile
 ======================================
 
-There are specification file types in Hashdist.  The *profile spec*
+There are specification file types in HashDist.  The *profile spec*
 describes *what* to build; what packages should be included in the
 profile and the options for each package. A *package spec* contains
 the *how* part: A (possibly parametrized) description for building a
 single package.
 
 The basic language of the specification files is YAML, see
-http://yaml.org.  Style guide: For YAML files within the Hashdist
+http://yaml.org.  Style guide: For YAML files within the HashDist
 project, we use 2 space indents, and no indent before
 vertically-formatted lists (as seen below).
 
@@ -16,7 +16,7 @@ Profile specification
 ---------------------
 
 The profile spec is what the user points the `hit` tool to to build a profile.
-By following references in it, Hashdist should be able to find all the information
+By following references in it, HashDist should be able to find all the information
 needed (including the package specification files). An example end-user profile
 might look like this::
 
@@ -135,7 +135,7 @@ given parameters. One of the files may lack the **when** clause
 (conventionally, the one without a dash and a suffix), which
 corresponds to a default fallback file.
 
-Also, Hashdist searches in the package directories for ``mypkg.py``,
+Also, HashDist searches in the package directories for ``mypkg.py``,
 which specifies a Python module with hook functions that can further
 influence the build. Documentation for the Python hook system is TBD,
 and the API tentative. Examples in ``base/autotools.py`` in the
@@ -147,7 +147,7 @@ we will not repeat them here, but simply list documentation on each clause.
 In strings; ``{{param_name}}`` will usually expand to the parameter in
 question while assembling the specification needed, and are expanded
 before artifact hashes are computed. Expansions of the form ``${FOO}``
-are expanded at build-time (by the Hashdist build system or the shell,
+are expanded at build-time (by the HashDist build system or the shell,
 depending on context), and the variable name is what is hashed.
 
 

--- a/doc/source/userguide.rst
+++ b/doc/source/userguide.rst
@@ -1,12 +1,12 @@
-User's guide to Hashdist
+User's guide to HashDist
 ========================
 
 Installing and making the `hit` tool available
 ----------------------------------------------
 
-Hashdist requires Python 2.7 and git.
+HashDist requires Python 2.7 and git.
 
-To start using Hashdist, clone the repo that contains the core tool, and put
+To start using HashDist, clone the repo that contains the core tool, and put
 the ``bin``-directory in your ``PATH``::
 
     $ git clone https://github.com/hashdist/hashdist.git 
@@ -25,13 +25,13 @@ beneath ``~/.hashdist``.  To change this, edit
 Setting up your software profile
 --------------------------------
 
-Using Hashdist is based on the following steps:
+Using HashDist is based on the following steps:
 
  1) First, describe the software profile you want to build in a configuration file ("I want Python, NumPy, SciPy").
 
  2) Use a dedicated git repository to manage that configuration file
 
- 3) For every git commit, Hashdist will be able to build the specified
+ 3) For every git commit, HashDist will be able to build the specified
     profile, and *cache* the results, so that you can jump around in
     the history of your software profile.
 
@@ -78,13 +78,13 @@ to build.
 Garbage collection
 ------------------
 
-Hashdist does not have the concepts of "upgrade" or "uninstall", but
+HashDist does not have the concepts of "upgrade" or "uninstall", but
 simply keeps everything it has downloaded or built around forever. To
 free up disk space, you may invoke the garbage collector to remove
 unused builds.
 
 Currently the garbage collection strategy is very simple: When you
-invoke garbage collection manually, Hashdist removes anything that
+invoke garbage collection manually, HashDist removes anything that
 isn't currently in use. To figure out what that means, you may invoke
 ``hit gc --list``; continueing on the example from above, we
 would find::
@@ -95,12 +95,12 @@ would find::
 
 This indicates that if you run a plain ``hit gc``, software accessible
 through ``/path/to/myprofile/default`` will be kept, but all other builds
-will be removed from the Hashdist store. To try it, you may comment out
+will be removed from the HashDist store. To try it, you may comment out
 the ``zlib`` line from ``default.yaml``, then run ``hit build``, and
 then ``hit gc`` -- the zlib software is removed at the last step.
 
 If you want to manipulate profile symlinks, you should use the ``hit
-cp``, ``hit mv``, and ``hit rm`` commands, so that Hashdist can
+cp``, ``hit mv``, and ``hit rm`` commands, so that HashDist can
 correctly track the profile links. This is useful to keep multiple
 profiles around. E.g., if you first execute::
 
@@ -120,7 +120,7 @@ an underscore in front), or manually remove symlinks.
 
    As a corollary to the description above, if you do a plain
    ``mv`` of a symlink to a profile, and then execute ``hit gc``,
-   then the software profile may be deleted by Hashdist.
+   then the software profile may be deleted by HashDist.
 
 
 Debug features
@@ -142,7 +142,7 @@ A couple of commands allow you to see what happens when building.
 
 This extracts Jinja2 sources to ``bld``, puts a Bash build-script in
 ``bld/_hashdist/build.sh``. However, if you go ahead and try to run it
-the environment will not be the same as when Hashdist builds, so this
+the environment will not be the same as when HashDist builds, so this
 is a bit limited so far. [TODO: ``hit debug`` which also sets the right
 environment and sets the ``$ARTIFACT`` directory.]
 

--- a/hashdist/cli/build_tools_cli.py
+++ b/hashdist/cli/build_tools_cli.py
@@ -203,7 +203,7 @@ class BuildPostprocess(object):
 
         The technique used depends on the value; multiline will use a
         polyglot script fragment to insert a 'multi-line shebang',
-        while 'launcher' will use the Hashdist 'launcher' tool. The
+        while 'launcher' will use the HashDist 'launcher' tool. The
         latter looks for the path to the 'launcher' artifact in the
         LAUNCHER environment variable.
 

--- a/hashdist/cli/frontend_cli.py
+++ b/hashdist/cli/frontend_cli.py
@@ -112,7 +112,7 @@ class Build(ProfileFrontendBase):
 @register_subcommand
 class Develop(ProfileFrontendBase):
     """
-    Builds a development profile in the Hashdist YAML profile spec
+    Builds a development profile in the HashDist YAML profile spec
     format, at the same location as the profile yaml file, but without
     the .yaml suffix.
 
@@ -146,7 +146,7 @@ class Develop(ProfileFrontendBase):
 @register_subcommand
 class Status(ProfileFrontendBase):
     """
-    Status a profile in the Hashdist YAML profile spec format, and
+    Status a profile in the HashDist YAML profile spec format, and
     outputs a symlink to the resulting profile at the same location
     without the .yaml suffix.
     """
@@ -261,7 +261,7 @@ class MvCpBase(object):
             f = open(artifact_id_file)
         except IOError as e:
             if e.errno == errno.ENOENT:
-                sys.stderr.write('Symlink does not point to a Hashdist artifact: %s\n' % args.source)
+                sys.stderr.write('Symlink does not point to a HashDist artifact: %s\n' % args.source)
                 return 1
             else:
                 raise
@@ -279,7 +279,7 @@ class MvCpBase(object):
 @register_subcommand
 class CP(MvCpBase):
     """
-    Copies a Hashdist profile symlink while keeping GC references up
+    Copies a HashDist profile symlink while keeping GC references up
     to date.
 
     You may manually manipulate GC references by modifying the
@@ -290,7 +290,7 @@ class CP(MvCpBase):
 @register_subcommand
 class MV(MvCpBase):
     """
-    Moves a Hashdist profile symlink while keeping GC references in sync.
+    Moves a HashDist profile symlink while keeping GC references in sync.
 
     You may manually manipulate GC references by modifying the
     gc_roots directory (see configuration file)
@@ -304,7 +304,7 @@ class MV(MvCpBase):
 @register_subcommand
 class RM(object):
     """
-    Removes a Hashdist profile symlink while keeping GC references in sync.
+    Removes a HashDist profile symlink while keeping GC references in sync.
 
     You may manually manipulate GC references by modifying the
     gc_roots directory (see configuration file).

--- a/hashdist/cli/main.py
+++ b/hashdist/cli/main.py
@@ -48,7 +48,7 @@ def register_subcommand(cls, command=None):
     _subcommands[name] = cls
     return cls
 
-class HashdistCommandContext(object):
+class HashDistCommandContext(object):
     def __init__(self, argparser, subcommand_parsers, out_stream, config_filename, env, logger):
         self.argparser = argparser
         self.subcommand_parsers = subcommand_parsers
@@ -102,7 +102,7 @@ def command_line_entry_point(unparsed_argv, env, logger, default_config_filename
     """The main ``hit`` command-line entry point
     """
     description = textwrap.dedent('''
-    Entry-point for various Hashdist command-line tools
+    Entry-point for various HashDist command-line tools
     ''')
 
     parser = argparse.ArgumentParser(description=description,
@@ -142,7 +142,7 @@ def command_line_entry_point(unparsed_argv, env, logger, default_config_filename
         if args.verbose:
             logger.set_level(DEBUG)
 
-        ctx = HashdistCommandContext(parser, subcmd_parsers, sys.stdout, args.config_file, env, logger)
+        ctx = HashDistCommandContext(parser, subcmd_parsers, sys.stdout, args.config_file, env, logger)
 
         retcode = args.subcommand_handler(ctx, args)
         if retcode is None:

--- a/hashdist/core/build_store.py
+++ b/hashdist/core/build_store.py
@@ -5,15 +5,15 @@
 Principles
 ----------
 
-The build store is the very core of Hashdist: Producing build artifacts
+The build store is the very core of HashDist: Producing build artifacts
 identified by hash-IDs. It's important to have a clear picture of just
 what the build store is responsible for and not.
 
 Nix takes a pure approach where an artifact hash is guaranteed to
 identify the resulting binaries (up to anything inherently random in
 the build process, like garbage left by compilers). In contrast,
-Hashdist takes a much more lenient approach where the strictness is
-configurable. The primary goal of Hashdist is to make life simpler
+HashDist takes a much more lenient approach where the strictness is
+configurable. The primary goal of HashDist is to make life simpler
 by reliably triggering rebuilds when software components are updated,
 not total control of the environment (in which case Nix is likely
 the better option).
@@ -29,7 +29,7 @@ parallel.
 Artifact IDs
 ------------
 
-A Hashdist artifact ID has the form ``name/hash``, e.g.,
+A HashDist artifact ID has the form ``name/hash``, e.g.,
 ``zlib/4niostz3iktlg67najtxuwwgss5vl6k4``.
 
 For the artifact paths on disk, a shortened form (4-char hash) is used
@@ -347,7 +347,7 @@ class BuildStore(object):
                     self.logger.error('    %s (wants to access/build)' % artifact_id)
                     self.logger.error('')
                     self.logger.error('The odds of this happening due to chance are very low.')
-                    self.logger.error('Please get in touch with the Hashdist developer mailing list.')
+                    self.logger.error('Please get in touch with the HashDist developer mailing list.')
                     raise IllegalBuildStoreError('Hashes collide in first 12 chars: %s and %s' % (present_id, artifact_id))
             return path
 
@@ -439,7 +439,7 @@ class BuildStore(object):
         write_protect(fname)
 
     def _encode_symlink(self, symlink):
-        """Format of Hashdist-managed entries in gc_roots directory; an underscore + base64"""
+        """Format of HashDist-managed entries in gc_roots directory; an underscore + base64"""
         return '_' + base64.b64encode(symlink).replace('=', '-')
 
     def create_symlink_to_artifact(self, artifact_id, symlink_target):

--- a/hashdist/core/build_tools.py
+++ b/hashdist/core/build_tools.py
@@ -392,7 +392,7 @@ def make_relative_multiline_shebang(build_store, filename, scriptlines):
     ----------
 
     build_store : BuildStore
-        Used to identify shebangs that reference paths within Hashdist artifacts
+        Used to identify shebangs that reference paths within HashDist artifacts
 
     scriptlines : list of str
         List of lines in the script; each line includes terminating newline

--- a/hashdist/core/cache.py
+++ b/hashdist/core/cache.py
@@ -4,7 +4,7 @@
 
 Building artifact descriptions can be time-consuming if it involves,
 e.g., probing the host system for information and so on. This is
-simply a key-value store stored in a central location for Hashdist
+simply a key-value store stored in a central location for HashDist
 (typically ``~/.hit/cache``). Anything in the cache can be removed
 without further notice.
 """

--- a/hashdist/core/hasher.py
+++ b/hashdist/core/hasher.py
@@ -202,7 +202,7 @@ class Hasher(DocumentSerializer):
     Cryptographically hashes buffers or nested objects ("JSON-like" object structures).
     See :class:`DocumentSerializer` for more details.
 
-    This is the standard hashing method of Hashdist.
+    This is the standard hashing method of HashDist.
     """
     def __init__(self, x=None):
         DocumentSerializer.__init__(self, hash_type())
@@ -214,13 +214,13 @@ class Hasher(DocumentSerializer):
 
     def format_digest(self):
         """
-        The Hashdist standard digest.
+        The HashDist standard digest.
         """
         return format_digest(self._wrapped)
 
 
 def format_digest(hasher):
-    """The Hashdist standard format for encoding hash digests
+    """The HashDist standard format for encoding hash digests
 
     This is one of the cases where it is prudent to just repeat the
     implementation in the docstring::

--- a/hashdist/core/hit_recipe.py
+++ b/hashdist/core/hit_recipe.py
@@ -20,7 +20,7 @@ def hit_cli_build_spec(python=None, package=None):
     without executing commands.
 
     It is created with the Python interpreter currently running,
-    loading the Hashdist package currently running (i.e.,
+    loading the HashDist package currently running (i.e.,
     independent of any "python" dependency in the build spec).
 
     Parameters
@@ -30,7 +30,7 @@ def hit_cli_build_spec(python=None, package=None):
         Path to Python interpreter to use (default: ``sys.executable``)
 
     package : str
-        Path to Hashdist package to use (default: deduced from ``__file__``)
+        Path to HashDist package to use (default: deduced from ``__file__``)
 
     Returns
     -------
@@ -84,9 +84,9 @@ def hit_cli_build_spec(python=None, package=None):
 def ensure_hit_cli_artifact(build_store, config):
     """
     Builds an artifact which executes the 'hit' command using the current
-    Python interpreter and current Hashdist package.
+    Python interpreter and current HashDist package.
 
-    Note: The current Hashdist package is merely symlinked to, the
+    Note: The current HashDist package is merely symlinked to, the
     hash of the artifact doesn't mean much. See this as a way for the
     running process to inject a CLI into the build environment.
 

--- a/hashdist/core/run_job.py
+++ b/hashdist/core/run_job.py
@@ -673,7 +673,7 @@ class CommandTreeExecution(object):
                     f.write("export %s='%s'\n" % (key, value))
 
             with working_directory(env['PWD']):
-                sys.stderr.write('Entering Hashdist debug mode. Please execute the following command: \n')
+                sys.stderr.write('Entering HashDist debug mode. Please execute the following command: \n')
                 sys.stderr.write('  %s\n' % args)
                 sys.stderr.write('\n')
                 sys.stderr.write('When you are done, "exit 1" to abort build, or "exit 0" to continue.\n\n')

--- a/hashdist/formats/config.example.yaml
+++ b/hashdist/formats/config.example.yaml
@@ -1,4 +1,4 @@
-## Configuration file for Hashdist
+## Configuration file for HashDist
 
 ## All relative paths are relative to the directory containing this
 ## configuration file.

--- a/hashdist/formats/config.py
+++ b/hashdist/formats/config.py
@@ -1,5 +1,5 @@
 """
-Handles reading the Hashdist configuration file. By default this is
+Handles reading the HashDist configuration file. By default this is
 ``~/.hashdist/config.yaml``.
 """
 
@@ -15,7 +15,7 @@ DEFAULT_CONFIG_DIRS = ('ba', 'bld', 'src', 'db', 'cache', 'gcroots')
 
 config_schema = {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "Hashdist configuration file schema",
+    "title": "HashDist configuration file schema",
     "type": "object",
     "properties": {
         "build_stores": {

--- a/hashdist/spec/hook_api.py
+++ b/hashdist/spec/hook_api.py
@@ -4,7 +4,7 @@ A significant portion of the package building logic should eventually find
 its way into here.
 
 Hook files are re-loaded for every package build, and so decorators etc.
-are run again. The machinery used to Hashdist to load hook files is
+are run again. The machinery used to HashDist to load hook files is
 found in .hook.
 """
 import types

--- a/hashdist/spec/profile.py
+++ b/hashdist/spec/profile.py
@@ -1,5 +1,5 @@
 """
-:mod:`hashdist.spec.profile` --- Hashdist Profiles
+:mod:`hashdist.spec.profile` --- HashDist Profiles
 ==================================================
 
 Not supported:


### PR DESCRIPTION
With:

  $ sed -i 's/Hashdist/HashDist/g' $(git grep -l Hashdist)
  $ sed -i 's/HashDistdoc/HashDistDoc/g' $(git grep -l HashDistdoc)

This might create silly conflicts with outstanding branches.  They
should be trivial to resolve, but it's also easy for me to re-run the
seds after outstanding PRs land.
