### PR TITLE
Fix hook file discovery if the profile contains use:

### DIFF
--- a/hashdist/spec/package.py
+++ b/hashdist/spec/package.py
@@ -52,8 +52,7 @@ class PackageSpec(object):
         package_parameters['package'] = name
         from package_loader import PackageLoader
         loader = PackageLoader(name, package_parameters,
-                               load_yaml=profile.load_package_yaml,
-                               find_file=profile.find_package_file)
+                               load_yaml=profile.load_package_yaml)
         return PackageSpec(name, loader.stages_topo_ordered(),
                            loader.get_hook_files(), loader.parameters)
 

--- a/hashdist/spec/package_loader.py
+++ b/hashdist/spec/package_loader.py
@@ -34,11 +34,10 @@ class PackageLoaderBase(object):
     The sections to merge, see :meth:`merge_stages` and meth:`topo_order`
     """
 
-    def __init__(self, name, parameters, load_yaml, find_file):
+    def __init__(self, name, parameters, load_yaml):
         self.name = name
         self.parameters = parameters
         self.load_yaml = load_yaml
-        self.find_file = find_file
         self.load_documents()
         self.apply_defaults()
         self.process_conditionals()
@@ -108,7 +107,7 @@ class PackageLoaderBase(object):
 
     def _load_parent(self, parent_name):
         """Helper for :meth:`load_parents` """
-        parent = PackageLoaderBase(parent_name, self.parameters, self.load_yaml, self.find_file)
+        parent = PackageLoaderBase(parent_name, self.parameters, self.load_yaml)
         all_names = set(p.name for p in self.all_parents)
         new_names = set(p.name for p in parent.all_parents)
         if all_names.intersection(new_names):
@@ -211,7 +210,7 @@ class PackageLoader(PackageLoaderBase):
         All parents, direct and indirect
     """
 
-    def __init__(self, name, parameters, load_yaml, find_file):
+    def __init__(self, name, parameters, load_yaml):
         """
         Load package yaml and postprocess it.
 
@@ -228,12 +227,8 @@ class PackageLoader(PackageLoaderBase):
         load_yaml : function
             Callable to load the yaml, see
             :meth:`hashdist.spec.profile.load_package_yaml`.
-
-        find_file : function
-            Callable to find auxiliary files, see
-            :meth:`hashdist.spec.profile.find_package_file`.
         """
-        super(PackageLoader, self).__init__(name, parameters, load_yaml, find_file)
+        super(PackageLoader, self).__init__(name, parameters, load_yaml)
         self.override_requested_sources()
         self.expand_globs_in_build_stages_files()
 
@@ -329,8 +324,7 @@ class PackageLoader(PackageLoaderBase):
         """
         hook_files = []
         for loader in self.all_parents + [self]:
-            py_file = loader.name + '.py'
-            hook = self.find_file(loader.name, py_file)
+            hook = loader.package_file.hook_filename
             if hook:
                 hook_files.append(hook)
         return hook_files

--- a/hashdist/spec/tests/test_stack/use_alternate_package/altdirectory/altdirectory.yaml
+++ b/hashdist/spec/tests/test_stack/use_alternate_package/altdirectory/altdirectory.yaml
@@ -1,0 +1,14 @@
+# Example package-with-directory
+# This tests overriding origdirectory with a use: directive
+
+defaults:
+  # dummy variable so we can see which package was loaded
+  filename: altdirectory.yaml
+
+build_stages:
+- name: refer_to_file
+  files: [alternate_file.txt]
+
+profile_links:
+  - name: everything
+    link: '*/altdirectory/*'

--- a/hashdist/spec/tests/test_stack/use_alternate_package/altdirectory/alternate_file.txt
+++ b/hashdist/spec/tests/test_stack/use_alternate_package/altdirectory/alternate_file.txt
@@ -1,0 +1,1 @@
+Example of a file referenced in a build stage files: section

--- a/hashdist/spec/tests/test_stack/use_alternate_package/base.yaml
+++ b/hashdist/spec/tests/test_stack/use_alternate_package/base.yaml
@@ -1,3 +1,6 @@
 packages:
   base_original:
     use: base_alternate
+
+  base_origdirectory:
+    use: base_altdirectory

--- a/hashdist/spec/tests/test_stack/use_alternate_package/base_altdirectory/base_altdirectory.yaml
+++ b/hashdist/spec/tests/test_stack/use_alternate_package/base_altdirectory/base_altdirectory.yaml
@@ -1,0 +1,14 @@
+# Example package-with-directory
+# This tests overriding origdirectory with a use: directive
+
+defaults:
+  # dummy variable so we can see which package was loaded
+  filename: base_altdirectory.yaml
+
+build_stages:
+- name: refer_to_file
+  files: [base_alternate_file.txt]
+
+profile_links:
+  - name: everything
+    link: '*/base_altdirectory/*'

--- a/hashdist/spec/tests/test_stack/use_alternate_package/base_altdirectory/base_alternate_file.txt
+++ b/hashdist/spec/tests/test_stack/use_alternate_package/base_altdirectory/base_alternate_file.txt
@@ -1,0 +1,1 @@
+Example of a file referenced in a build stage files: section

--- a/hashdist/spec/tests/test_stack/use_alternate_package/base_origdirectory/base_origdirectory.yaml
+++ b/hashdist/spec/tests/test_stack/use_alternate_package/base_origdirectory/base_origdirectory.yaml
@@ -1,0 +1,7 @@
+# Example package-with-directory
+
+defaults:
+  # dummy variable so we can see which package was loaded
+  filename: base_origdirectory.yaml
+
+

--- a/hashdist/spec/tests/test_stack/use_alternate_package/base_origdirectory/base_original_file.txt
+++ b/hashdist/spec/tests/test_stack/use_alternate_package/base_origdirectory/base_original_file.txt
@@ -1,0 +1,1 @@
+Example of a file referenced in a build stage files: section

--- a/hashdist/spec/tests/test_stack/use_alternate_package/hooks/altdirectory.py
+++ b/hashdist/spec/tests/test_stack/use_alternate_package/hooks/altdirectory.py
@@ -1,0 +1,3 @@
+"""
+Example profile hook
+"""

--- a/hashdist/spec/tests/test_stack/use_alternate_package/hooks/alternate.py
+++ b/hashdist/spec/tests/test_stack/use_alternate_package/hooks/alternate.py
@@ -1,0 +1,3 @@
+"""
+Example profile hook
+"""

--- a/hashdist/spec/tests/test_stack/use_alternate_package/hooks/base_altdirectory.py
+++ b/hashdist/spec/tests/test_stack/use_alternate_package/hooks/base_altdirectory.py
@@ -1,0 +1,3 @@
+"""
+Example profile hook
+"""

--- a/hashdist/spec/tests/test_stack/use_alternate_package/hooks/base_alternate.py
+++ b/hashdist/spec/tests/test_stack/use_alternate_package/hooks/base_alternate.py
@@ -1,0 +1,3 @@
+"""
+Example profile hook
+"""

--- a/hashdist/spec/tests/test_stack/use_alternate_package/hooks/base_origdirectory.py
+++ b/hashdist/spec/tests/test_stack/use_alternate_package/hooks/base_origdirectory.py
@@ -1,0 +1,3 @@
+"""
+Example hook file
+"""

--- a/hashdist/spec/tests/test_stack/use_alternate_package/hooks/base_original.py
+++ b/hashdist/spec/tests/test_stack/use_alternate_package/hooks/base_original.py
@@ -1,0 +1,3 @@
+"""
+Example profile hook
+"""

--- a/hashdist/spec/tests/test_stack/use_alternate_package/hooks/origdirectory.py
+++ b/hashdist/spec/tests/test_stack/use_alternate_package/hooks/origdirectory.py
@@ -1,0 +1,3 @@
+"""
+Example hook file
+"""

--- a/hashdist/spec/tests/test_stack/use_alternate_package/hooks/original.py
+++ b/hashdist/spec/tests/test_stack/use_alternate_package/hooks/original.py
@@ -1,0 +1,3 @@
+"""
+Example profile hook
+"""

--- a/hashdist/spec/tests/test_stack/use_alternate_package/origdirectory/origdirectory.yaml
+++ b/hashdist/spec/tests/test_stack/use_alternate_package/origdirectory/origdirectory.yaml
@@ -1,0 +1,9 @@
+# Example package-with-directory
+
+defaults:
+  # dummy variable so we can see which package was loaded
+  filename: origdirectory.yaml
+
+build_stages:
+- name: refer_to_file
+  files: [original_file.txt]

--- a/hashdist/spec/tests/test_stack/use_alternate_package/origdirectory/original_file.txt
+++ b/hashdist/spec/tests/test_stack/use_alternate_package/origdirectory/original_file.txt
@@ -1,0 +1,1 @@
+Example of a file referenced in a build stage files: section

--- a/hashdist/spec/tests/test_stack/use_alternate_package/profile.yaml
+++ b/hashdist/spec/tests/test_stack/use_alternate_package/profile.yaml
@@ -4,6 +4,12 @@ extends:
 package_dirs:
 - .
 
+hook_import_dirs:
+- hooks
+
 packages:
   original:
     use: alternate
+
+  origdirectory:
+    use: altdirectory


### PR DESCRIPTION
The code for finding the hook file (if any) is moved into the
PackageYAML class which already encapsulates filesystem information.

This should fix https://github.com/hashdist/hashdist/issues/273
