### PR TITLE
Add parameter set/override from command line

### DIFF
--- a/hashdist/cli/utils.py
+++ b/hashdist/cli/utils.py
@@ -1,5 +1,11 @@
 import json
 
+try:
+    import argparse
+except ImportError:
+    from ..deps import argparse
+
+
 def fetch_parameters_from_json(filename, key):
     with file(filename) as f:
         doc = json.load(f)
@@ -11,3 +17,19 @@ def fetch_parameters_from_json(filename, key):
         except KeyError:
             raise Exception("Key %s not found in JSON document '%s'" % (key, filename))
     return doc
+
+
+def parameter_pair(string):
+    """Split a string based on the '=' delimiter into a pair of strings.
+
+    It is illegal for the first string to contain a '=' (since it will be split)
+    It is legal for the second string to contain the '=' character
+
+    :param string: Parameter string of the form, 'PATH=/usr/bin'
+    :return: Parameter tuple of the form ('PATH','/usr/bin')
+    """
+    try:
+        p1, p2 = string.split('=', 1)
+        return p1, p2
+    except:
+        raise argparse.ArgumentTypeError('Unable to parse as parameter: %r' % string)

--- a/hashdist/spec/profile.py
+++ b/hashdist/spec/profile.py
@@ -431,7 +431,7 @@ class FileResolver(object):
         return result
 
 
-def load_and_inherit_profile(checkouts, include_doc, cwd=None):
+def load_and_inherit_profile(checkouts, include_doc, cwd=None, override_parameters=None):
     """
     Loads a Profile given an include document fragment, e.g.::
 
@@ -502,8 +502,12 @@ def load_and_inherit_profile(checkouts, include_doc, cwd=None):
             doc[section].extend(parent_doc.get(section, []))
 
     # Merge parameters. Can't have the same parameter from more than one parent
-    # *unless* it's overriden by this document, in which case it's OK.
+    # *unless* it's overridden by this document or command line, in which case it's OK.
+
+    if override_parameters is not None:
+        doc['parameters'].update(override_parameters)
     parameters = doc.setdefault('parameters', {})
+
     overridden = parameters.keys()
     for parent_doc in parents:
         for k, v in parent_doc.get('parameters', {}).iteritems():
@@ -531,6 +535,6 @@ def load_and_inherit_profile(checkouts, include_doc, cwd=None):
     doc['packages'] = packages
     return doc
 
-def load_profile(logger, checkout_manager, profile_file):
-    doc = load_and_inherit_profile(checkout_manager, profile_file)
+def load_profile(logger, checkout_manager, profile_file, override_parameters=None):
+    doc = load_and_inherit_profile(checkout_manager, profile_file, None, override_parameters)
     return Profile(logger, doc, checkout_manager)


### PR DESCRIPTION
Parameters can now be set or overridden from the command line using the syntax:

x=y

An unlimited number of parameters can be set.  A current limitation is
that a parameter set at the command line may not contain the '=' sign,
as this is used to parse the split between the two parameters.

Some examples:

hit build -v profile.yaml HOST_MATLAB=~/bin/matlab
hit build -v scipy-stack.yaml pyver=3.4 PATH=/usr/local/bin:/usr/bin:/bin
