### PR TITLE
support remote build_stores, 'hit push', and 'hit remote-store --add'

### DIFF
--- a/hashdist/formats/config.py
+++ b/hashdist/formats/config.py
@@ -23,9 +23,9 @@ config_schema = {
             "items": {
                 "type": "object",
                 "properties": {
-                    "dir": {"type": "string"}
-                },
-                "required": ["dir"]
+                    "dir": {"type": "string"},
+                    "url": {"type": "string"},
+                }
             },
             "minItems": 1
         },
@@ -71,7 +71,8 @@ def load_config_file(filename, logger):
     doc = load_yaml_from_file(filename)
     validate_yaml(doc, config_schema)
     for entry in doc['build_stores']:
-        entry['dir'] = _ensure_dir(_make_abs(basedir, entry['dir']), logger)
+        if entry.has_key('dir'):
+            entry['dir'] = _ensure_dir(_make_abs(basedir, entry['dir']), logger)
 
     for entry in doc['source_caches']:
         if sum(['url' in entry, 'dir' in entry]) != 1:


### PR DESCRIPTION
This is just a straw man on support for remote build stores. Obviously it would be nice to have relocatable binaries, but I was interested also in the work flow for remotes and what could be done now without tackling the relocation and package format issues. There are a lot of cases where it would be handy even without relocatability, such as CI build environments, ipython notebook servers, SMC, and some HPC systems.  This branch adds

- support for multiple build_store mirrors in .hashdist/config.yaml (have to edit by hand)
- a `remote-store` sub-command for setting up a remote file server on a cloud service
- a `push` sub-command for pushing your build artifacts

The subcommands require the Python API for personal cloud service web apps from here: https://github.com/netheosgithub/pcs_api, which I grabbed based on @dagss suggestion, apologies if I grabbed the wrong implementation.

Examples:

```bash
hit remote-store --add --pcs="dropbox" --appName="hash_app_linux" \
--appID=X --appSecret=Y
hit push
```
where  you get `X` and `Y` from your cloud storage service by going to your account console and setting up an application. Unfortunately `hit push` pushes everything in your build store and leaves tarballs locally. Given the crating HDEP, I didn't see the point in doing anything more than simple hacks when it comes to creating, uploading, and downloading the "packages".

Then on some equivalent system/container you edit .hashdist/config.yaml to point to the remote build store and just do `hit build` as usual.
