### PR TITLE
Save profile name into profile's build.json

### DIFF
--- a/hashdist/cli/frontend_cli.py
+++ b/hashdist/cli/frontend_cli.py
@@ -107,7 +107,7 @@ class Build(ProfileFrontendBase):
                 self.builder.build(ready[0], self.ctx.get_config(), self.args.j,
                                    self.args.k, self.args.debug)
                 ready = self.builder.get_ready_list()
-            artifact_id, artifact_dir = self.builder.build_profile(self.ctx.get_config())
+            artifact_id, artifact_dir = self.builder.build_profile(self.ctx.get_config(), profile_symlink)
             self.build_store.create_symlink_to_artifact(artifact_id, profile_symlink)
             if was_done:
                 sys.stdout.write('Up to date, link at: %s\n' % profile_symlink)

--- a/hashdist/spec/builder.py
+++ b/hashdist/spec/builder.py
@@ -110,7 +110,8 @@ class ProfileBuilder(object):
                       for pkgname, build_spec in self._build_specs.iteritems())
         return report
 
-    def get_profile_build_spec(self, link_type='relative', write_protect=True):
+    def get_profile_build_spec(self, profile_name, link_type='relative',
+            write_protect=True):
         profile_list = [{"id": build_spec.artifact_id} for build_spec in self._build_specs.values()]
 
         # Topologically sort by run-time dependencies
@@ -136,6 +137,7 @@ class ProfileBuilder(object):
 
         return BuildSpec({
             "name": "profile",
+            "profile_name": profile_name,
             "version": "n",
             "build": {
                 "import": imports,
@@ -150,8 +152,8 @@ class ProfileBuilder(object):
                                         keep_build=keep_build, debug=debug)
         self._built.add(pkgname)
 
-    def build_profile(self, config):
-        profile_build_spec = self.get_profile_build_spec()
+    def build_profile(self, config, profile_name):
+        profile_build_spec = self.get_profile_build_spec(profile_name=profile_name)
         return self.build_store.ensure_present(profile_build_spec, config)
 
     def build_profile_out(self, target, config, link_type, debug=False):


### PR DESCRIPTION
Now the build.json in a profile looks like:
```
{
  "build" : {
    "commands" : [
      {
        "prepend_path" : "PATH",
        "value" : "${PYTHON_DIR}/bin"
      },
      ....
    ]
  },
  "name" : "profile",
  "profile_name" : "d2",
  "version" : "n"
}
```
Where there is now a new field 'profile_name' with the name of the profile.

Note: the 'name' field must be "profile", so that all profiles end up under bld/profile.


Now we can use this to lookup a profile by name at runtime. @dagss currently this only makes it into the `build.json`. How do I make it also appear in `artifact.json`, which should be the file to be consulted later on with other `hit` tools (see #325 for such tools that will use this)?