### PR TITLE
Implement `hit load profile`

### DIFF
--- a/hashdist/__init__.py
+++ b/hashdist/__init__.py
@@ -1,2 +1,5 @@
 from .spec.hook_api import *
 
+import os
+hashdist_dir = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
+hashdist_share_dir = os.path.join(hashdist_dir, "share", "hashdist")

--- a/hashdist/cli/frontend_cli.py
+++ b/hashdist/cli/frontend_cli.py
@@ -7,6 +7,8 @@ from pprint import pprint
 from .main import register_subcommand, DEFAULT_CONFIG_FILENAME_REPR
 import errno
 from .utils import parameter_pair
+from ..util.ansi_color import color
+from .. import hashdist_share_dir
 
 def add_build_args(ap):
     ap.add_argument('-j', metavar='CPUCOUNT', default=1, type=int, help='number of CPU cores to utilize')
@@ -246,6 +248,70 @@ class GC(object):
         else:
             build_store = BuildStore.create_from_config(ctx.get_config(), ctx.logger)
             build_store.gc()
+
+
+@register_subcommand
+class LoadProfile(object):
+    __doc__ = """
+    Loads a given profile.
+
+    Example:
+
+        $ hit load py32
+
+    This sets the HASHSTACK environemnt variable to point to the root of the
+    profile (you can then use it when building other code by hand, e.g. 'gcc
+    -I$HASHSTACK/include') and adds $HASHSTACK/bin into your PATH.
+
+    This command requires the hit's shell commands to be initialized (it will
+    print instructions how to do so if they are not).
+
+    You can examine the Bash commands that are being executed by:
+
+        $ hit load --print-bash-commands py32
+
+    """
+
+    command = 'load'
+
+    @staticmethod
+    def setup(ap):
+        ap.add_argument('profile', help='profile to load')
+        ap.add_argument('--print-bash-commands', action='store_true', help='print Bash commands to load the profile')
+
+    @staticmethod
+    def run(ctx, args):
+        if args.print_bash_commands:
+            from ..core import BuildStore
+            gc_roots_dir = ctx.get_config()['gc_roots']
+            for gc_root in os.listdir(gc_roots_dir):
+                profile_name = os.path.basename(os.readlink(pjoin(gc_roots_dir,
+                    gc_root)))
+                if profile_name == args.profile:
+                    break
+            else:
+                raise Exception("Profile '%s' not installed" % args.profile)
+            try:
+                profile_path = os.readlink(os.readlink(pjoin(gc_roots_dir, gc_root)))
+            except OSError:
+                # FIXME: query our runtime database instead, it should be there
+                raise Exception("Profile '%s' was deleted" % args.profile)
+            profile_hash = os.path.basename(profile_path)
+            profile_name_ui = profile_name + "/" + profile_hash
+            profile_name_ui_color = profile_name + color.turquoise("/" + \
+                    profile_hash)
+
+            sys.stdout.write('export HASHSTACK="%s"\n' % profile_path)
+            sys.stdout.write('export PATH="${HASHSTACK}/bin":${PATH}\n')
+            sys.stdout.write('echo "Exporting HASHSTACK=$HASHSTACK"\n')
+            sys.stdout.write("""echo "Adding \\${HASHSTACK}/bin to PATH"\n""")
+            sys.stdout.write('echo "Profile %s loaded."\n' % profile_name_ui)
+        else:
+            sys.stdout.write("This command requires hit's shell integration.\n\n")
+            sys.stdout.write("To initialize hit's shell commands, you must run in Bash:\n\n")
+            sys.stdout.write('    . %s/setup-env.sh\n\n' % hashdist_share_dir)
+            sys.stdout.write("You can execute this line by hand or add it to your '.bashrc'. After that,\nrerun your last command.\n")
+
 
 class MvCpBase(object):
     @classmethod

--- a/share/hashdist/setup-env.sh
+++ b/share/hashdist/setup-env.sh
@@ -1,0 +1,25 @@
+# This file is part of Hashdist to setup Hashdist environment for bash.
+#
+# We provide a 'hit' Bash function, that checks for subcommand is called. If it
+# is "load" or "unload", then it hooks them up with Bash to do the right thing.
+# Otherwise it just forwards the arguments to the 'hit' program.
+
+function hit {
+    _hit_subcommand=$1;
+
+    case $_hit_subcommand in
+        "load"|"unload")
+            hit_commands="$(command hit "$@" --print-bash-commands)"
+            if [ $? -eq 0 ]; then
+                # Evaluate the commands that hit supplied using Bash
+                eval "$hit_commands"
+            else
+                # If there was an error in hit, show the error messages
+                echo "$hit_commands"
+            fi
+            ;;
+        *)
+            command hit "$@"
+            ;;
+    esac
+}

--- a/share/hashdist/setup-env.sh
+++ b/share/hashdist/setup-env.sh
@@ -1,6 +1,6 @@
 # This file is part of Hashdist to setup Hashdist environment for bash.
 #
-# We provide a 'hit' Bash function, that checks for subcommand is called. If it
+# We provide a 'hit' Bash function, that checks for the subcommand called. If it
 # is "load" or "unload", then it hooks them up with Bash to do the right thing.
 # Otherwise it just forwards the arguments to the 'hit' program.
 


### PR DESCRIPTION
And add hit commandline support

@cekees, @dagss this is the most useful part of #325, which I need for my work. It doesn't conflict with any commands and the implementation, while not perfect, is reasonably simple and robust. I want this in, so that I can use it.

The way I use it is that it prints the command to execute in bash to load the bash utilities, and I put it into my .bashrc. Then `hit load profile` works out of the box, all the time.