### PR TITLE
Rename build.log to _hashdist/build.log

### DIFF
--- a/hashdist/core/build_store.py
+++ b/hashdist/core/build_store.py
@@ -111,7 +111,7 @@ are set:
     scripts.
 
 The build specification is available under ``$BUILD/build.json``, and
-stdout and stderr are redirected to ``$BUILD/build.log``. These two
+stdout and stderr are redirected to ``$BUILD/_hashdist/build.log``. These two
 files will also be present in ``$ARTIFACT`` after the build.
 
 Build artifact storage format
@@ -618,7 +618,8 @@ class ArtifactBuilder(object):
         os.mkdir(job_tmp_dir)
         job_spec = self.build_spec.doc['build']
 
-        log_filename = pjoin(build_dir, 'build.log')
+        os.mkdir(pjoin(build_dir, '_hashdist'))
+        log_filename = pjoin(build_dir, '_hashdist', 'build.log')
         self.logger.warning('Building %s, follow log with:' % self.build_spec.short_artifact_id)
         self.logger.warning('  tail -f %s' % log_filename)
         self.logger.debug('Start log output to file %s', log_filename)

--- a/hashdist/core/test/test_build_store.py
+++ b/hashdist/core/test/test_build_store.py
@@ -124,8 +124,9 @@ def test_basic(tempdir, sc, bldr, config):
         got = sorted(f.readlines())
         eq_(''.join(got), dedent('''\
         .
+        ./_hashdist
+        ./_hashdist/build.log
         ./build.json
-        ./build.log
         ./build.sh
         ./job
         ./subdir


### PR DESCRIPTION
This fixes issue [#441](https://github.com/hashdist/hashstack/issues/441) in hashstack.