### PR TITLE
Fix trivial git doctest failures

### DIFF
--- a/hashdist/core/test/test_source_cache.py
+++ b/hashdist/core/test/test_source_cache.py
@@ -113,6 +113,8 @@ def make_mock_git_repo(submodules=None):
     with working_directory(mock_git_repo):
         repo = os.path.join(mock_git_repo, '.git')
         git('init', repo=repo)
+        git('config', 'user.name', 'Hashdist User', repo=repo)
+        git('config', 'user.email', 'hashdistuser@example.com', repo=repo)
         cat('README', 'First revision')
         git('add', 'README', repo=repo)
         if submodules:

--- a/hashdist/spec/tests/test_profile.py
+++ b/hashdist/spec/tests/test_profile.py
@@ -18,6 +18,8 @@ from ..exceptions import ProfileError
 def gitify(dir):
     with working_directory(dir):
         subprocess.check_call(['git', 'init'], stdout=open(os.devnull, 'wb'))
+        subprocess.check_call(['git', 'config', 'user.name', 'Hashdist User'], stdout=open(os.devnull, 'wb'))
+        subprocess.check_call(['git', 'config', 'user.email', 'hashdistuser@example.com'], stdout=open(os.devnull, 'wb'))
         subprocess.check_call(['git', 'add', '.'], stdout=open(os.devnull, 'wb'))
         subprocess.check_call(['git', 'commit', '-m', 'Initial commit'], stdout=open(os.devnull, 'wb'))
         p = subprocess.Popen(['git', 'rev-parse', 'HEAD'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
Probably a recent change that git errors out if no email/name is set:
~~~~
$ tox
GLOB sdist-make: /home/vbraun/Code/HashDist/hashdist/setup.py
py26 create: /home/vbraun/Code/HashDist/hashdist/.tox/py26
ERROR: InterpreterNotFound: python2.6
py27 inst-nodeps: /home/vbraun/Code/HashDist/hashdist/.tox/dist/hashdist-0.3.zip
py27 installed: hashdist==0.3,nose==1.3.7
py27 runtests: PYTHONHASHSEED='685223659'
py27 runtests: commands[0] | nosetests --with-doctest
..........S.........................................................E....S.........F..............
*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'vbraun@volker-desktop.(none)')
E...
*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'vbraun@volker-desktop.(none)')
E...................
======================================================================
ERROR: test suite for <module 'hashdist.core.test.test_source_cache' from '/home/vbraun/Code/HashDist/hashdist/hashdist/core/test/test_source_cache.pyc'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/vbraun/Code/HashDist/hashdist/.tox/py27/lib/python2.7/site-packages/nose/suite.py", line 209, in run
    self.setUp()
  File "/home/vbraun/Code/HashDist/hashdist/.tox/py27/lib/python2.7/site-packages/nose/suite.py", line 292, in setUp
    self.setupContext(ancestor)
  File "/home/vbraun/Code/HashDist/hashdist/.tox/py27/lib/python2.7/site-packages/nose/suite.py", line 315, in setupContext
    try_run(context, names)
  File "/home/vbraun/Code/HashDist/hashdist/.tox/py27/lib/python2.7/site-packages/nose/util.py", line 471, in try_run
    return func()
  File "/home/vbraun/Code/HashDist/hashdist/hashdist/core/test/test_source_cache.py", line 49, in setup
    mock_git_repo, mock_git_commit, mock_git_devel_branch_commit = make_mock_git_repo(mock_git_repo)
  File "/home/vbraun/Code/HashDist/hashdist/hashdist/core/test/test_source_cache.py", line 126, in make_mock_git_repo
    git('commit', '-m', 'First revision', repo=repo)
  File "/home/vbraun/Code/HashDist/hashdist/hashdist/core/test/test_source_cache.py", line 104, in git
    raise RuntimeError('git call %r failed with code %d' % (args, p.returncode))
RuntimeError: git call ('commit', '-m', 'First revision') failed with code 128

======================================================================
ERROR: hashdist.spec.tests.test_profile.test_load_and_inherit_profile_dir_treatment
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/vbraun/Code/HashDist/hashdist/.tox/py27/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/vbraun/Code/HashDist/hashdist/hashdist/core/test/utils.py", line 110, in replacement
    return func(d)
  File "/home/vbraun/Code/HashDist/hashdist/hashdist/spec/tests/test_profile.py", line 92, in test_load_and_inherit_profile_dir_treatment
    commit = gitify(pjoin(d, 'gitrepo'))
  File "/home/vbraun/Code/HashDist/hashdist/hashdist/spec/tests/test_profile.py", line 22, in gitify
    subprocess.check_call(['git', 'commit', '-m', 'Initial commit'], stdout=open(os.devnull, 'wb'))
  File "/usr/lib64/python2.7/subprocess.py", line 540, in check_call
    raise CalledProcessError(retcode, cmd)
CalledProcessError: Command '['git', 'commit', '-m', 'Initial commit']' returned non-zero exit status 128

======================================================================
ERROR: hashdist.spec.tests.test_profile.test_temp_git_checkouts
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/vbraun/Code/HashDist/hashdist/.tox/py27/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/vbraun/Code/HashDist/hashdist/hashdist/core/test/utils.py", line 110, in replacement
    return func(d)
  File "/home/vbraun/Code/HashDist/hashdist/hashdist/spec/tests/test_profile.py", line 50, in test_temp_git_checkouts
    repo1_commit = 'git:' + gitify(repo1_dir)
  File "/home/vbraun/Code/HashDist/hashdist/hashdist/spec/tests/test_profile.py", line 22, in gitify
    subprocess.check_call(['git', 'commit', '-m', 'Initial commit'], stdout=open(os.devnull, 'wb'))
  File "/usr/lib64/python2.7/subprocess.py", line 540, in check_call
    raise CalledProcessError(retcode, cmd)
CalledProcessError: Command '['git', 'commit', '-m', 'Initial commit']' returned non-zero exit status 128
~~~~
Trivial fix is to set name/email local to the test repo.