### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,10 +5,10 @@ HashDist
     https://hashdist.github.io/
 
 **Docs**:
-    http://hashdist.readthedocs.org/
+    https://hashdist.readthedocs.io/
 
 **Tutorial:**
-    http://hashdist.readthedocs.org/en/latest/tutorial.html
+    https://hashdist.readthedocs.io/en/latest/tutorial.html
 
 **Code:**
     https://github.com/hashdist/hashdist


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
